### PR TITLE
[BE] 유효성 검사와 Swagger 문서 적용 완료

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,7 +11,7 @@
     "start": "nest start",
     "start:dev": "npm run prebuild && cross-env NODE_ENV=development nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "npm run prebuild && cross-env NODE_ENV=production node dist/main",
+    "start:prod": "cross-env NODE_ENV=production node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/server/src/apis/auth/auth.controller.ts
+++ b/server/src/apis/auth/auth.controller.ts
@@ -1,14 +1,38 @@
-import { Controller, Post, Body, HttpStatus, HttpCode, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  HttpStatus,
+  HttpCode,
+  Res,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginUserDto } from './dto/login-user.dto';
 import { Response } from 'express';
 import { AuthGuard } from './auth.guard';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 
 @Controller('auth')
+@ApiTags('Auth API')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
+  @ApiOperation({ summary: '로그인' })
+  @ApiOkResponse({ description: '로그인 성공 시 토큰 반환' })
+  @ApiNotFoundResponse({ description: 'fail- User not found' })
+  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.OK)
   async login(@Body() loginUserDto: LoginUserDto, @Res() res: Response) {
     const acceccToken = await this.authService.login(loginUserDto);
@@ -18,11 +42,16 @@ export class AuthController {
       maxAge: 1000 * 60 * 60 * 24 * 7,
     });
 
-    res.json({ message: 'success' });
+    res.json(acceccToken);
   }
 
   @UseGuards(AuthGuard)
   @Post('logout')
+  @ApiOperation({ summary: '로그아웃' })
+  @ApiBearerAuth('accessToken')
+  @ApiOkResponse({ description: '로그아웃 성공 시 쿠키의 토큰 삭제' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
+  @ApiForbiddenResponse({ description: 'fail - Invaild token' })
   async logout(@Res() res: Response) {
     res.clearCookie('accessToken');
     res.sendStatus(HttpStatus.NO_CONTENT);

--- a/server/src/apis/auth/auth.guard.ts
+++ b/server/src/apis/auth/auth.guard.ts
@@ -2,7 +2,7 @@ import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
-import { JwtPayloadDto } from './dto/jwt-payload.dto';
+import { JwtPayload } from './auth.interface';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -18,7 +18,7 @@ export class AuthGuard implements CanActivate {
     }
     try {
       const secretKey = this.configService.get<string>('SECRET_KEY');
-      const payload: JwtPayloadDto = await this.jwtService.verifyAsync(acceccToken, {
+      const payload: JwtPayload = await this.jwtService.verifyAsync(acceccToken, {
         secret: secretKey,
       });
       request['user'] = payload;

--- a/server/src/apis/auth/auth.interface.ts
+++ b/server/src/apis/auth/auth.interface.ts
@@ -1,4 +1,4 @@
-export class JwtPayloadDto {
+export interface JwtPayload {
   id: number;
   email: string;
 }

--- a/server/src/apis/auth/auth.service.ts
+++ b/server/src/apis/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { LoginUserDto } from './dto/login-user.dto';
 import { UsersService } from '../users/users.service';
 import * as bcrypt from 'bcrypt';
 import { JwtService } from '@nestjs/jwt';
-import { JwtPayloadDto } from './dto/jwt-payload.dto';
+import { JwtPayload } from './auth.interface';
 
 @Injectable()
 export class AuthService {
@@ -20,7 +20,7 @@ export class AuthService {
       throw new UnauthorizedException();
     }
 
-    const payload: JwtPayloadDto = {
+    const payload: JwtPayload = {
       id: user.id,
       email: user.email,
     };

--- a/server/src/apis/auth/dto/login-user.dto.ts
+++ b/server/src/apis/auth/dto/login-user.dto.ts
@@ -1,4 +1,4 @@
-export class LoginUserDto {
-  email: string;
-  password: string;
-}
+import { PickType } from '@nestjs/swagger';
+import { CreateUserDto } from 'src/apis/users/dto/create-user.dto';
+
+export class LoginUserDto extends PickType(CreateUserDto, ['email', 'password'] as const) {}

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -17,7 +17,7 @@ import { CreateSideQuestDto } from './dto/create-side-quest.dto';
 import { UpdateSideQuestDto } from './dto/update-side-quest.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../../common/decorators/auth.decorator';
-import { JwtPayloadDto } from '../auth/dto/jwt-payload.dto';
+import { JwtPayload } from '../auth/auth.interface';
 
 @Controller('quests')
 export class QuestsController {
@@ -26,14 +26,14 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Post('')
   @HttpCode(HttpStatus.CREATED)
-  async create(@CurrentUser() user: JwtPayloadDto, @Body() createQuestDto: CreateQuestDto) {
+  async create(@CurrentUser() user: JwtPayload, @Body() createQuestDto: CreateQuestDto) {
     return await this.questsService.create(user.id, createQuestDto);
   }
 
   @UseGuards(AuthGuard)
   @Get('main')
   @HttpCode(HttpStatus.OK)
-  async findAll(@CurrentUser() user: JwtPayloadDto) {
+  async findAll(@CurrentUser() user: JwtPayload) {
     return await this.questsService.findAll(user.id);
   }
 
@@ -48,7 +48,7 @@ export class QuestsController {
   @Patch('main/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async update(
-    @CurrentUser() user: JwtPayloadDto,
+    @CurrentUser() user: JwtPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateQuestDto
   ) {
@@ -58,7 +58,7 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Delete('main/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async remove(@CurrentUser() user: JwtPayloadDto, @Param('id') id: string) {
+  async remove(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
     await this.questsService.remove(user.id, +id);
   }
 
@@ -80,7 +80,7 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Get('sub')
   @HttpCode(HttpStatus.OK)
-  findAllSub(@CurrentUser() user: JwtPayloadDto) {
+  findAllSub(@CurrentUser() user: JwtPayload) {
     return this.questsService.findAll(user.id);
   }
 
@@ -95,7 +95,7 @@ export class QuestsController {
   @Patch('sub/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateSub(
-    @CurrentUser() user: JwtPayloadDto,
+    @CurrentUser() user: JwtPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateQuestDto
   ) {
@@ -105,7 +105,7 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Delete('sub/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async removeSub(@CurrentUser() user: JwtPayloadDto, @Param('id') id: string) {
+  async removeSub(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
     await this.questsService.remove(user.id, +id);
   }
 }

--- a/server/src/apis/ranking/dto/ranking-response.dto.ts
+++ b/server/src/apis/ranking/dto/ranking-response.dto.ts
@@ -1,15 +1,15 @@
-import { UserInfo } from 'src/apis/users/entities/user-info.entity';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { UserResponseDto } from 'src/apis/users/dto/user-response.dto';
 
-export class RankingResponseDto {
-  id: number;
-  nickname: string;
-  point: number;
+export class RankingResponseDto extends PickType(UserResponseDto, [
+  'id',
+  'nickname',
+  'point',
+] as const) {
+  @ApiProperty({
+    example: 1,
+    description: '순위',
+    required: true,
+  })
   rank: number;
-
-  constructor(userInfo: UserInfo, rank: number) {
-    this.id = userInfo.userId;
-    this.nickname = userInfo.nickname;
-    this.point = userInfo.point;
-    this.rank = rank;
-  }
 }

--- a/server/src/apis/ranking/ranking.controller.ts
+++ b/server/src/apis/ranking/ranking.controller.ts
@@ -1,12 +1,24 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 import { RankingService } from './ranking.service';
+import { RankingResponseDto } from './dto/ranking-response.dto';
+import {
+  ApiInternalServerErrorResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 
 @Controller('ranking')
+@ApiTags('Ranking API')
 export class RankingController {
   constructor(private readonly rankingService: RankingService) {}
 
   @Get()
-  findAllRanking() {
+  @ApiOperation({ summary: '랭킹 조회' })
+  @ApiOkResponse({ type: RankingResponseDto, isArray: true })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  @HttpCode(HttpStatus.OK)
+  findAllRanking(): Promise<RankingResponseDto[]> {
     return this.rankingService.getRanking();
   }
 }

--- a/server/src/apis/ranking/ranking.service.ts
+++ b/server/src/apis/ranking/ranking.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { RankingResponseDto } from './dto/ranking-response.dto';
+import { UserInfo } from '../users/entities/user-info.entity';
 
 @Injectable()
 export class RankingService {
@@ -19,11 +20,20 @@ export class RankingService {
         countCurrentRank++;
       }
 
-      const rankedUser = new RankingResponseDto(user, currentRank);
+      const rankedUser = this.toRankingResponse(user, currentRank);
 
       lastUserPoint = user.point;
       return rankedUser;
     });
     return ranking;
+  }
+
+  private toRankingResponse(userInfo: UserInfo, rank: number): RankingResponseDto {
+    return {
+      id: userInfo.userId,
+      nickname: userInfo.nickname,
+      point: userInfo.point,
+      rank: rank,
+    };
   }
 }

--- a/server/src/apis/users/dto/create-user.dto.ts
+++ b/server/src/apis/users/dto/create-user.dto.ts
@@ -1,5 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, Length } from 'class-validator';
+
 export class CreateUserDto {
+  @ApiProperty({
+    example: 'test@gmail.com',
+    description: '이메일',
+    required: true,
+  })
+  @IsEmail()
+  @IsNotEmpty()
   email: string;
+
+  @ApiProperty({
+    example: 'qwer1234',
+    description: '8 ~ 30 이하 비밀번호',
+    required: true,
+  })
+  @IsNotEmpty()
+  @Length(8, 30)
   password: string;
+
+  @ApiProperty({
+    example: 'InGame',
+    description: '2 ~ 30 이하 닉네임',
+    required: true,
+  })
+  @IsNotEmpty()
+  @Length(2, 20)
   nickname: string;
 }

--- a/server/src/apis/users/dto/profile-photo.dto.ts
+++ b/server/src/apis/users/dto/profile-photo.dto.ts
@@ -1,3 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
 export class ProfilePhotoDto {
+  @ApiProperty({
+    description: '프로필 이미지 스트링 형태의 데이터',
+    required: false,
+  })
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
   profilePhoto: string;
 }

--- a/server/src/apis/users/dto/update-user.dto.ts
+++ b/server/src/apis/users/dto/update-user.dto.ts
@@ -1,4 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+
 export class UpdateUserDto {
-  nickname?: string;
+  @ApiProperty({
+    example: 'InGame',
+    description: '2 ~ 30 이하 닉네임',
+    required: true,
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Length(2, 20)
+  nickname: string;
+
+  @ApiProperty({
+    example: '자기소개입니다.',
+    description: '0 ~ 50 이하 자기소개 글',
+    required: true,
+  })
+  @IsOptional()
+  @IsString()
+  @Length(0, 50)
   intro?: string;
 }

--- a/server/src/apis/users/dto/user-response.dto.ts
+++ b/server/src/apis/users/dto/user-response.dto.ts
@@ -1,19 +1,45 @@
-import { User } from '../entities/user.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: 'id',
+    required: true,
+  })
   id: number;
-  email: string;
-  nickname: string;
-  intro: string | null;
-  profilePhoto: string | null;
-  point: number;
 
-  constructor(user: User) {
-    this.id = user.id;
-    this.email = user.email;
-    this.nickname = user.userInfo.nickname;
-    this.intro = user.userInfo.intro || null;
-    this.profilePhoto = user.profilePhoto.profilePhoto || null;
-    this.point = user.userInfo.point;
-  }
+  @ApiProperty({
+    example: 'test@gmail.com',
+    description: '이메일',
+    required: true,
+  })
+  email: string;
+
+  @ApiProperty({
+    example: 'test',
+    description: '닉네임',
+    required: true,
+  })
+  nickname: string;
+
+  @ApiProperty({
+    example: null,
+    description: '자기소개',
+    required: false,
+  })
+  intro: string | null;
+
+  @ApiProperty({
+    example: null,
+    description: '프로필 사진',
+    required: false,
+  })
+  profilePhoto: string | null;
+
+  @ApiProperty({
+    example: 0,
+    description: '포인트 점수',
+    required: true,
+  })
+  point: number;
 }

--- a/server/src/apis/users/users.controller.ts
+++ b/server/src/apis/users/users.controller.ts
@@ -8,20 +8,41 @@ import {
   HttpCode,
   Patch,
   UseGuards,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from 'src/common/decorators/auth.decorator';
-import { JwtPayloadDto } from '../auth/dto/jwt-payload.dto';
+import { JwtPayload } from '../auth/auth.interface';
 import { ProfilePhotoDto } from './dto/profile-photo.dto';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { UserResponseDto } from './dto/user-response.dto';
 
 @Controller('users')
+@ApiTags('Users API')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post('signup')
+  @ApiOperation({ summary: '회원가입' })
+  @ApiCreatedResponse({ description: 'success' })
+  @ApiConflictResponse({ description: '이미 존재하는 회원입니다.' })
+  @ApiBody({ type: CreateUserDto })
+  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.CREATED)
   async signup(@Body() createUserDto: CreateUserDto) {
     await this.usersService.createUser(createUserDto);
@@ -30,30 +51,54 @@ export class UsersController {
 
   @UseGuards(AuthGuard)
   @Delete('me')
+  @ApiOperation({ summary: '회원탈퇴' })
+  @ApiBearerAuth('accessToken')
+  @ApiNoContentResponse()
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
+  @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteUser(@CurrentUser() user: JwtPayloadDto) {
+  async deleteUser(@CurrentUser() user: JwtPayload) {
     await this.usersService.deleteCurrentUserById(user.id);
   }
 
   @UseGuards(AuthGuard)
   @Get('me')
+  @ApiOperation({ summary: '나의 정보 조회' })
+  @ApiBearerAuth('accessToken')
+  @ApiOkResponse({ type: UserResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
+  @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.OK)
-  async getCurrentUser(@CurrentUser() user: JwtPayloadDto) {
+  async getCurrentUser(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
     return await this.usersService.getUserById(user.id);
   }
 
   @UseGuards(AuthGuard)
   @Patch('me')
+  @ApiOperation({ summary: '사용자 정보 수정' })
+  @ApiBearerAuth('accessToken')
+  @ApiNoContentResponse({ description: '사용자 정보 수정 성공' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
+  @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
+  @ApiConflictResponse({ description: '닉네임이 이미 사용 중입니다' })
+  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
-  async updateUserInfo(@CurrentUser() user: JwtPayloadDto, @Body() updateUserDto: UpdateUserDto) {
+  async updateUserInfo(@CurrentUser() user: JwtPayload, @Body() updateUserDto: UpdateUserDto) {
+    console.log(user);
     await this.usersService.updateCurrenUserInfoById(user.id, updateUserDto);
   }
 
   @UseGuards(AuthGuard)
   @Patch('me/profile-photo')
+  @ApiOperation({ summary: '프로필 사진 수정' })
+  @ApiBearerAuth('accessToken')
+  @ApiNoContentResponse({ description: '프로필 사진 수정 성공' })
+  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
+  @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
+  @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateProfilePhoto(
-    @CurrentUser() user: JwtPayloadDto,
+    @CurrentUser() user: JwtPayload,
     @Body() profilePhotoDto: ProfilePhotoDto
   ) {
     await this.usersService.updateProfilePhotoById(user.id, profilePhotoDto);

--- a/server/src/apis/users/users.service.ts
+++ b/server/src/apis/users/users.service.ts
@@ -78,11 +78,12 @@ export class UsersService {
       throw new HttpException('fail - User not found', HttpStatus.NOT_FOUND);
     }
 
-    return new UserResponseDto(user);
+    return this.toUserResponse(user);
   }
 
   async updateCurrenUserInfoById(id: number, updateUserDto: UpdateUserDto): Promise<void> {
     const userInfo = await this.userInfoRepository.findOne({ where: { userId: id } });
+    console.log(userInfo);
     if (!userInfo) {
       throw new HttpException('fail - User not found', HttpStatus.NOT_FOUND);
     }
@@ -132,5 +133,16 @@ export class UsersService {
       },
     });
     return users;
+  }
+
+  private toUserResponse(user: User): UserResponseDto {
+    return {
+      id: user.id,
+      email: user.email,
+      nickname: user.userInfo.nickname,
+      intro: user.userInfo.intro ?? null,
+      profilePhoto: user.profilePhoto.profilePhoto ?? null,
+      point: user.userInfo.point,
+    };
   }
 }

--- a/server/src/common/config/swagger.config.ts
+++ b/server/src/common/config/swagger.config.ts
@@ -6,6 +6,7 @@ export function setupSwagger(app: INestApplication): void {
     .setTitle('InGame API 문서')
     .setDescription('InGame API Swagger 문서입니다.')
     .setVersion('1.0.0')
+    .addBasicAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }, 'accessToken')
     .build();
 
   const document = SwaggerModule.createDocument(app, options);

--- a/server/src/common/filters/all-exception.filter.ts
+++ b/server/src/common/filters/all-exception.filter.ts
@@ -24,6 +24,7 @@ export class AllExceptionFilter implements ExceptionFilter {
       timestamp: datetime,
       path: req.url,
       method: req.method,
+      message: message,
     };
     const args = req.body;
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -15,9 +15,7 @@ async function bootstrap() {
   const origin = configService.get<string>('CORS_ORIGIN');
 
   setupSwagger(app);
-
   app.use(cookieParser());
-
   app.enableCors({
     origin: origin,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',


### PR DESCRIPTION
<strong>
Closes #64 
</strong>

### 💡 다음 이슈를 해결했어요.

#### Bearer 토큰 사용할 수 있도록 설정 수정
```ts
import { INestApplication } from '@nestjs/common';
import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';

export function setupSwagger(app: INestApplication): void {
  const options = new DocumentBuilder()
    .setTitle('InGame API 문서')
    .setDescription('InGame API Swagger 문서입니다.')
    .setVersion('1.0.0')
    .addBasicAuth({ type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }, 'accessToken')
    .build();

  const document = SwaggerModule.createDocument(app, options);
  SwaggerModule.setup('api-docs', app, document);
}
```
#### Swagger 인증 사용 방법
- 자물쇠 버튼 클릭
![스크린샷 2024-05-09 오후 11 29 55](https://github.com/ingame-app/ingame/assets/107787137/f3eb7257-bcb0-4c24-90bc-6320b3a68277)

- 토큰 입력 후 `Authorize` 버튼 클릭
![스크린샷 2024-05-09 오후 11 30 18](https://github.com/ingame-app/ingame/assets/107787137/30572173-7326-4b63-ad09-b04e0c409eeb)

#### `DTO`에 `Swagger` 설정과 `class-validator` 적용
- `ApiProperty`를 통해 API의 예시와 설명을 보여줌
- class-validator를 통해 유효성 검증
```ts
import { ApiProperty } from '@nestjs/swagger';
import { IsEmail, IsNotEmpty, Length } from 'class-validator';

export class CreateUserDto {
  @ApiProperty({
    example: 'test@gmail.com',
    description: '이메일',
    required: true,
  })
  @IsEmail()
  @IsNotEmpty()
  email: string;

  @ApiProperty({
    example: 'qwer1234',
    description: '8 ~ 30 이하 비밀번호',
    required: true,
  })
  @IsNotEmpty()
  @Length(8, 30)
  password: string;

  @ApiProperty({
    example: 'InGame',
    description: '2 ~ 30 이하 닉네임',
    required: true,
  })
  @IsNotEmpty()
  @Length(2, 20)
  nickname: string;
}
```

- `controller`의 각 API마다 `Pipe` 설정
```ts
@UsePipes(ValidationPipe)
```
- API 성공하거나 실패했을 때,Swagger에 보여줄 설정 추가
- `type` 설정으로 응답 데이터의 예시 보여줌
```ts
 @UseGuards(AuthGuard)
  @Get('me')
  @ApiOperation({ summary: '나의 정보 조회' })
  @ApiBearerAuth('accessToken')
  @ApiOkResponse({ type: UserResponseDto })
  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
  @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
  @HttpCode(HttpStatus.OK)
  async getCurrentUser(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
    return await this.usersService.getUserById(user.id);
  }
```
#### `JwtPayloadDto`를 인터페이스로 변경
- 내부적으로 만드는 토큰에 들어갈 값이라 Dto보다 인터페이스를 이용하는 것이 적절하다고 판단
```ts
// auth.interface.ts
export interface JwtPayload {
  id: number;
  email: string;
}
```

#### `UserResponseDto`와 `RankingResponseDto` 수정
- 이전에는 각 Dto에서 전달할 객체를 생성
- 단일책임원칙을 적용하기 위해 생성하는 코드 제거
- UsersService와 RankingService에서 메소드를 이용하여 생성
```ts
// users.service.ts
  private toUserResponse(user: User): UserResponseDto {
    return {
      id: user.id,
      email: user.email,
      nickname: user.userInfo.nickname,
      intro: user.userInfo.intro ?? null,
      profilePhoto: user.profilePhoto.profilePhoto ?? null,
      point: user.userInfo.point,
    };
  }

// ranking.service.ts
  private toRankingResponse(userInfo: UserInfo, rank: number): RankingResponseDto {
    return {
      id: userInfo.userId,
      nickname: userInfo.nickname,
      point: userInfo.point,
      rank: rank,
    };
  }
```

### 💡 다음 자료를 참고하면 좋아요.

- [NestJS Operations 문서](https://docs.nestjs.com/openapi/operations)
- [NestJS Validation 문서](https://docs.nestjs.com/techniques/validation)
### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
