### PR TITLE
[BE] User API 수정 완료

### DIFF
--- a/server/src/apis/ranking/dto/ranking-response.dto.ts
+++ b/server/src/apis/ranking/dto/ranking-response.dto.ts
@@ -1,11 +1,7 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { UserResponseDto } from 'src/apis/users/dto/user-response.dto';
+import { UserProfileDto } from 'src/apis/users/dto/user-profile.dto';
 
-export class RankingResponseDto extends PickType(UserResponseDto, [
-  'id',
-  'nickname',
-  'point',
-] as const) {
+export class UserRankingDto extends PickType(UserProfileDto, ['id', 'nickname', 'point'] as const) {
   @ApiProperty({
     example: 1,
     description: '순위',

--- a/server/src/apis/ranking/ranking.controller.ts
+++ b/server/src/apis/ranking/ranking.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
 import { RankingService } from './ranking.service';
-import { RankingResponseDto } from './dto/ranking-response.dto';
+import { UserRankingDto } from './dto/ranking-response.dto';
 import {
   ApiInternalServerErrorResponse,
   ApiOkResponse,
@@ -15,10 +15,10 @@ export class RankingController {
 
   @Get()
   @ApiOperation({ summary: '랭킹 조회' })
-  @ApiOkResponse({ type: RankingResponseDto, isArray: true })
+  @ApiOkResponse({ type: UserRankingDto, isArray: true })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.OK)
-  findAllRanking(): Promise<RankingResponseDto[]> {
+  findAllRanking(): Promise<UserRankingDto[]> {
     return this.rankingService.getRanking();
   }
 }

--- a/server/src/apis/ranking/ranking.service.ts
+++ b/server/src/apis/ranking/ranking.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
-import { RankingResponseDto } from './dto/ranking-response.dto';
+import { UserRankingDto } from './dto/ranking-response.dto';
 import { UserInfo } from '../users/entities/user-info.entity';
 
 @Injectable()
 export class RankingService {
   constructor(private readonly usersService: UsersService) {}
-  async getRanking(): Promise<RankingResponseDto[]> {
+  async getRanking(): Promise<UserRankingDto[]> {
     const users = await this.usersService.getAllUser();
     let currentRank = 1;
     let lastUserPoint = 0;
@@ -28,7 +28,7 @@ export class RankingService {
     return ranking;
   }
 
-  private toRankingResponse(userInfo: UserInfo, rank: number): RankingResponseDto {
+  private toRankingResponse(userInfo: UserInfo, rank: number): UserRankingDto {
     return {
       id: userInfo.userId,
       nickname: userInfo.nickname,

--- a/server/src/apis/users/dto/user-profile.dto.ts
+++ b/server/src/apis/users/dto/user-profile.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UserResponseDto {
+export class UserProfileDto {
   @ApiProperty({
     example: 1,
     description: 'id',

--- a/server/src/apis/users/users.controller.ts
+++ b/server/src/apis/users/users.controller.ts
@@ -10,6 +10,8 @@ import {
   UseGuards,
   UsePipes,
   ValidationPipe,
+  Param,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -25,12 +27,13 @@ import {
   ApiCreatedResponse,
   ApiForbiddenResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { UserResponseDto } from './dto/user-response.dto';
+import { UserProfileDto } from './dto/user-profile.dto';
 
 @Controller('users')
 @ApiTags('Users API')
@@ -65,11 +68,11 @@ export class UsersController {
   @Get('me')
   @ApiOperation({ summary: '나의 정보 조회' })
   @ApiBearerAuth('accessToken')
-  @ApiOkResponse({ type: UserResponseDto })
+  @ApiOkResponse({ type: UserProfileDto })
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.OK)
-  async getCurrentUser(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
+  async getCurrentUser(@CurrentUser() user: JwtPayload): Promise<UserProfileDto> {
     return await this.usersService.getUserById(user.id);
   }
 
@@ -84,7 +87,6 @@ export class UsersController {
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateUserInfo(@CurrentUser() user: JwtPayload, @Body() updateUserDto: UpdateUserDto) {
-    console.log(user);
     await this.usersService.updateCurrenUserInfoById(user.id, updateUserDto);
   }
 
@@ -102,5 +104,14 @@ export class UsersController {
     @Body() profilePhotoDto: ProfilePhotoDto
   ) {
     await this.usersService.updateProfilePhotoById(user.id, profilePhotoDto);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: '특정 유저의 정보 조회' })
+  @ApiOkResponse({ type: UserProfileDto })
+  @ApiNotFoundResponse({ description: 'Fail - User not found' })
+  @HttpCode(HttpStatus.OK)
+  async getUser(@Param('id', ParseIntPipe) id: number): Promise<UserProfileDto> {
+    return await this.usersService.getUserById(id);
   }
 }


### PR DESCRIPTION
<strong>
Closes #67 
</strong>


### 💡 다음 이슈를 해결했어요.

- 특정 유저 조회 기능 추가
- 로그인 시 잘못된 이메일을 입력했을 때, 에러 보내도록 수정

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 특정 유저 조회 기능 추가

```ts
  @Get(':id')
  @ApiOperation({ summary: '특정 유저의 정보 조회' })
  @ApiOkResponse({ type: UserProfileDto })
  @ApiNotFoundResponse({ description: 'Fail - User not found' })
  @HttpCode(HttpStatus.OK)
  async getUser(@Param('id', ParseIntPipe) id: number): Promise<UserProfileDto> {
    return await this.usersService.getUserById(id);
  }
```

#### 로그인 시 잘못된 이메일을 입력했을 때, 에러 보내도록 수정

```ts
  async getUserByEmail(email: string): Promise<User> {
    const user = await this.userRepository.findOne({
      where: { email },
    });
    if (!user) {
      throw new HttpException('Fail - User not found', HttpStatus.NOT_FOUND);
    }
    return user;
  }
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [x] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
