### PR TITLE
[BE] 퀘스트 API 컨트롤러 JwtPayloadDto에서 JwtPayload 인터페이스로 변경

### DIFF
--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -58,7 +58,7 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Post('side')
   @HttpCode(HttpStatus.OK)
-  createSide(@CurrentUser() user: JwtPayloadDto, @Body() createQuestDto: CreateSideQuestDto) {
+  createSide(@CurrentUser() user: JwtPayload, @Body() createQuestDto: CreateSideQuestDto) {
     return this.questsService.createSide(user.id, createQuestDto);
   }
 
@@ -66,7 +66,7 @@ export class QuestsController {
   @Patch('side/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
   updateSide(
-    @CurrentUser() user: JwtPayloadDto,
+    @CurrentUser() user: JwtPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateSideQuestDto
   ) {
@@ -76,7 +76,7 @@ export class QuestsController {
   @UseGuards(AuthGuard)
   @Delete('side/:id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  removeSide(@CurrentUser() user: JwtPayloadDto, @Param('id') id: string) {
+  removeSide(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
     return this.questsService.removeSide(user.id, +id);
   }
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 퀘스트 API 컨트롤러 `JwtPayloadDto` 미변경으로 인한 서버 실행 불가 증상 해결
  <br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 각 메서드 `JwtPayloadDto` -> `JwtPayload` 변경
  <br><br>

### 💡 필요한 후속작업이 있어요.

- (없음)
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없음)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
