### PR TITLE
[FE] 버그 수정 userIntro에 초기값이 null을 받았을 때의 오류 해결

### DIFF
--- a/client/src/components/EditProfileButton.tsx
+++ b/client/src/components/EditProfileButton.tsx
@@ -7,7 +7,7 @@ import ProfileModal from './modals/ProfileModal';
 interface EditProfileButtonProps {
   isOpen?: boolean;
   nickname: string;
-  intro: string;
+  intro: string | null;
 }
 
 const EditProfileButton = ({ isOpen = false, nickname, intro }: EditProfileButtonProps) => {

--- a/client/src/components/modals/ProfileModal.tsx
+++ b/client/src/components/modals/ProfileModal.tsx
@@ -12,19 +12,20 @@ import { useState } from 'react';
 
 interface ProfileModifyProps {
   nickname: string,
-  intro: string
+  intro: string | null,
 }
 
 interface ProfileProps {
   onClose: () => void;
   OriginNickname: string;
-  OriginIntro: string;
+  OriginIntro: string | null;
 }
+
 
 const ProfileModal = ({ onClose, OriginNickname, OriginIntro }: ProfileProps) => {
   const [nickname, setNickname] = useState(OriginNickname);
   const [intro, setIntro] = useState(OriginIntro);
-  const [inputCount, setInputCount] = useState(OriginIntro.length);
+  const [inputCount, setInputCount] = useState<number>(OriginIntro === null ? 0 : OriginIntro.length);
   const [profileIntro, setprofileIntro] = useState(intro);
 
   const { register, handleSubmit } = useForm<ProfileModifyProps>();
@@ -59,7 +60,7 @@ const ProfileModal = ({ onClose, OriginNickname, OriginIntro }: ProfileProps) =>
             <FaUserPen size={24} />
             <p className="title">자기소개 변경</p>
           </div>
-          <ProfileIntroInputBox placeholder={intro} value={intro} inputCount={inputCount} {...register('intro')} onChange={(e) => {
+          <ProfileIntroInputBox placeholder={intro === null ? '' : intro} value={intro === null ? '' : intro} inputCount={inputCount} {...register('intro')} onChange={(e) => {
             setIntro(e.target.value);
             setInputCount(e.target.value.length);
             setprofileIntro(e.target.value);

--- a/client/src/hooks/useEditQuest.ts
+++ b/client/src/hooks/useEditQuest.ts
@@ -26,7 +26,7 @@ export const useEditQuest = () => {
 
   const onSubmit = handleSubmit((data) => {
     const hidden = (isPrivate ? 'TRUE' : 'FALSE') as QuestHiddenType;
-    const status = data.side.map(side => side.status ? 'complete' : 'on progress');
+    const status = data.side.map(side => side.status ? 'COMPLETED' : 'ON_PROGRESS');
     const newData = {...data, hidden, difficulty: isDifficulty, side: data.side.map((side, index) => ({...side, status: status[index]}))};
     EditQuestMutation.mutate(newData);
   });

--- a/client/src/models/user.model.ts
+++ b/client/src/models/user.model.ts
@@ -8,7 +8,7 @@ export interface User {
 
 export interface UserProfile {
   nickname: string;
-  intro: string;
+  intro: string | null;
 }
 
 export interface ProfilePhoto {

--- a/client/src/models/userInfo.model.ts
+++ b/client/src/models/userInfo.model.ts
@@ -2,7 +2,7 @@ export interface UserInfo {
   id: number;
   email: string;
   nickname: string;
-  intro: string;
+  intro: string | null;
   profilePhoto: string;
   point: number;
 }


### PR DESCRIPTION
Closes #84 

### 💡 다음 이슈를 해결했어요.

- [x] user -> intro의 초기값이 null 일때 발생하던 오류를 해결 했습니다 
- [x] sideQuest의 status 값 소문자에서 대문자로 변경

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ intro의 초기값이 null 일때 발생하던 오류를 해결
```ts
// models/user.model.ts
export interface UserProfile {
  nickname: string;
  intro: string | null;
}
```
<br><br>
```ts
// models/userInfo.model.ts
export interface UserInfo {
  id: number;
  email: string;
  nickname: string;
  intro: string | null;
  profilePhoto: string;
  point: number;
}
```
<br><br>
```tsx
// EditProfileButton
interface EditProfileButtonProps {
  isOpen?: boolean;
  nickname: string;
  intro: string | null;
}
```
<br><br>
```tsx
// ProfileModal.tsx
interface ProfileModifyProps {
  nickname: string,
  intro: string | null,
}

const [inputCount, setInputCount] = useState<number>(OriginIntro === null ? 0 : OriginIntro.length);

<ProfileIntroInputBox placeholder={intro === null ? '' : intro} value={intro === null ? '' : intro} inputCount={inputCount} {...register('intro')} onChange={(e) => {
   setIntro(e.target.value);
   setInputCount(e.target.value.length);
   setprofileIntro(e.target.value);
 }} />
```
#### 🛠️ sideQuest의 status 값 소문자에서 대문자로 변경
```ts
// useEditQuest.ts

const status = data.side.map(side => side.status ? 'COMPLETED' : 'ON_PROGRESS');
```

### 💡 필요한 후속작업이 있어요.

- [ ] 서버와 연결 후 확인

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
