### PR TITLE
[FE] 서브 퀘스트 상태값 변경

### DIFF
--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -1,11 +1,15 @@
 import { CreateSubQuestProps } from '@/components/modals/CreateSubQuestModal';
 import { SubQuestModifyProps } from '@/components/modals/SubQuestModal';
 import { API_END_POINT } from '@/constant/api';
-import { Quest, SubQuest } from '@/models/quest.model';
+import { Quest, QuestStatus, SubQuest } from '@/models/quest.model';
 import { httpClient } from '@/utils/axios';
 
 interface GetSubQuestParam {
   date: string;
+}
+export interface ModifyQuestStatusProps {
+  id: number;
+  status: QuestStatus;
 }
 
 export const createMainQuest = async (data: Quest) => {
@@ -36,9 +40,9 @@ export const addSubQuest = async (data: CreateSubQuestProps) => {
   return response.data;
 };
 
-export const modiSubQuestStatus = async (data: SubQuestModifyProps) => {
-  const response = await httpClient.patch(API_END_POINT.SUB_QUEST + `/${data.id}`, {
-    ...data,
+export const modiQuestStatus = async (data: ModifyQuestStatusProps) => {
+  const response = await httpClient.patch(API_END_POINT.CREATE_QUEST + `/${data.id}`, {
+    status: data.status,
   });
   return response.data;
 };

--- a/client/src/components/SubBox.tsx
+++ b/client/src/components/SubBox.tsx
@@ -21,8 +21,10 @@ const SubBox = ({ content }: SubBoxProps) => {
       let message = '';
       if (content.status === 'ON_PROGRESS') {
         message = '퀘스트를 완료하시겠습니까?';
+        content.status = 'COMPLETED';
       } else if (content.status === 'COMPLETED') {
         message = '퀘스트를 진행중으로 변경하시겠습니까?';
+        content.status = 'ON_PROGRESS';
       } else {
         return;
       }

--- a/client/src/hooks/useQuest.ts
+++ b/client/src/hooks/useQuest.ts
@@ -1,9 +1,14 @@
-import { addSubQuest, getSubQuest, modiSubQuest, modiSubQuestStatus } from '@/api/quests.api';
+import {
+  ModifyQuestStatusProps,
+  addSubQuest,
+  getSubQuest,
+  modiQuestStatus,
+  modiSubQuest,
+} from '@/api/quests.api';
 import { CreateSubQuestProps } from '@/components/modals/CreateSubQuestModal';
 import { SubQuestModifyProps } from '@/components/modals/SubQuestModal';
 import { QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
-import { QuestStatus } from '@/models/quest.model';
 import { formattedCalendar } from '@/utils/formatter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
@@ -36,15 +41,12 @@ export const useQuest = () => {
     onError(err) {},
   });
 
-  interface ModifySubQuestStatusProps {
-    id: number;
-    status: QuestStatus;
-  }
+  const modifySubQuestStatus = (data: ModifyQuestStatusProps) => {
+    modifyQuestStatusMutation.mutate(data);
+  };
 
-  const modifySubQuestStatus = (data: ModifySubQuestStatusProps) => {};
-
-  const modifySubQuestStatusMutation = useMutation({
-    mutationFn: modiSubQuestStatus,
+  const modifyQuestStatusMutation = useMutation({
+    mutationFn: modiQuestStatus,
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 서브퀘스트 상태값 변경 로직 추가

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
```tsx
//SubBox.tsx

...

const handleChangeStatue = () => {
    if (date === formattedCalendar(new Date())) {
      let message = '';
      if (content.status === 'ON_PROGRESS') {
        message = '퀘스트를 완료하시겠습니까?';
        content.status = 'COMPLETED';
      } else if (content.status === 'COMPLETED') {
        message = '퀘스트를 진행중으로 변경하시겠습니까?';
        content.status = 'ON_PROGRESS';
      } else {
        return;
      }

      showConfirm(message, () => {
        modifySubQuestStatus({ id: content.id, status: content.status });
      });
    } else {
      showAlert('당일 퀘스트만 수정 가능합니다');
    }
  };
...
```
//useQuest.ts
```ts
  const modifySubQuestStatus = (data: ModifyQuestStatusProps) => {
    modifyQuestStatusMutation.mutate(data);
  };

  const modifyQuestStatusMutation = useMutation({
    mutationFn: modiQuestStatus,
    onSuccess() {
      queryClient.invalidateQueries({
        queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
      });
    },
    onError(err) {},
  });
```
```ts
//quests.api.ts
...

export const modiQuestStatus = async (data: ModifyQuestStatusProps) => {
  const response = await httpClient.patch(API_END_POINT.CREATE_QUEST + `/${data.id}`, {
    status: data.status,
  });
  return response.data;
};
...
```

### 💡 필요한 후속작업이 있어요.

- (없다면 이 문항을 지워주세요.)
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없다면 이 문항을 지워주세요.)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
