### PR TITLE
[FE] 에러페이지 마크업 및 navigate 기능 구현

### DIFF
--- a/client/src/pages/Error.tsx
+++ b/client/src/pages/Error.tsx
@@ -1,13 +1,47 @@
 import styled from 'styled-components';
+import { MdErrorOutline } from 'react-icons/md';
+import Button from '@/components/Button';
 
 const Error = () => {
   return (
     <ErrorStyle>
-      <h1>Error</h1>
+      <ErrorContentStyle>
+        <MdErrorOutline size="60" />
+        <p className="error__text">잘못된 접근입니다.</p>
+      </ErrorContentStyle>
+      <Button size="large" color="blue">
+        메인페이지로 이동하기
+      </Button>
     </ErrorStyle>
   );
 };
 
-const ErrorStyle = styled.div``;
+const ErrorStyle = styled.div`
+  position: absolute;
+  top: 30%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  gap: 30px;
+`;
+
+const ErrorContentStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  gap: 20px;
+
+  .error__text {
+    font-size: ${({ theme }) => theme.font.xlarge};
+  }
+
+  svg {
+    color: ${({ theme }) => theme.color.coral};
+  }
+`;
 
 export default Error;

--- a/client/src/pages/Error.tsx
+++ b/client/src/pages/Error.tsx
@@ -1,16 +1,27 @@
 import styled from 'styled-components';
 import { MdErrorOutline } from 'react-icons/md';
 import Button from '@/components/Button';
+import { useSelector } from 'react-redux';
+import { isLoggedIn } from '@/store/authSlice';
+import { useNavigate } from 'react-router-dom';
+import { ROUTERS } from '@/constant/route';
 
 const Error = () => {
+  const isLogInUser = useSelector(isLoggedIn);
+  const navigate = useNavigate();
+
   return (
     <ErrorStyle>
       <ErrorContentStyle>
         <MdErrorOutline size="60" />
         <p className="error__text">잘못된 접근입니다.</p>
       </ErrorContentStyle>
-      <Button size="large" color="blue">
-        메인페이지로 이동하기
+      <Button
+        size="large"
+        color="blue"
+        onClick={() => navigate(`${isLogInUser ? ROUTERS.MAIN : ROUTERS.AUTH.LOGIN}`)}
+      >
+        {isLogInUser ? `메인페이지로 이동하기` : '로그인 페이지로 이동하기'}
       </Button>
     </ErrorStyle>
   );


### PR DESCRIPTION
**Closes #109**
## 💡 다음 이슈를 해결했어요.
- [x] 에러페이지 마크업 구현
- [x] 로그인 또는 로그아웃 상태 시, 버튼을 통해 메인 또는 로그인 페이지로 이동하는 기능 구현

## 💡 이슈를 처리하면서 추가된 코드가 있어요.
### 🛠 에러페이지 마크업 구현
로그인 유무에 따라 다른 버튼이 보여지도록 구현하였습니다.

```tsx
const Error = () => {
  const isLogInUser = useSelector(isLoggedIn);
  const navigate = useNavigate();

  return (
    <ErrorStyle>
      <ErrorContentStyle>
        <MdErrorOutline size="60" />
        <p className="error__text">잘못된 접근입니다.</p>
      </ErrorContentStyle>
      <Button
        size="large"
        color="blue"
        onClick={() => navigate(`${isLogInUser ? ROUTERS.MAIN : ROUTERS.AUTH.LOGIN}`)}
      >
        {isLogInUser ? `메인페이지로 이동하기` : '로그인 페이지로 이동하기'}
      </Button>
    </ErrorStyle>
  );
};
```

#### ✔︎ 로그인 상태일 때
<img width="500" alt="image" src="https://github.com/ingame-app/ingame/assets/62270427/8bd114e9-c912-4760-9971-453be943625b">

#### ✔︎ 비로그인 상태일 때
<img width="500" alt="image" src="https://github.com/ingame-app/ingame/assets/62270427/26f02fa6-4e73-48b7-90b6-055694ac9f16">


### 🛠 버튼을 통해 메인 또는 로그인 페이지로 이동하는 기능 구현
버튼 클릭 시, 로그인 상태일 때는 메인페이지로 / 비로그인 상태일 때는 로그인 페이지로 이동하도록 구현했습니다.

#### ✔︎ 로그인 상태일 때
<img width="300" src="https://github.com/ingame-app/ingame/assets/62270427/f53c6913-eb13-4c22-ad1d-aa105ec8b631"/>

#### ✔︎ 비로그인 상태일 때
<img width="300" src="https://github.com/ingame-app/ingame/assets/62270427/f8b12838-280b-425c-9208-9087a0aa789f"/>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
