### PR TITLE
[BE] 메인 퀘스트 개별 수정 시 사이드 퀘스트 수정이 가능하도록 변경 및 일부 코드 수정

### DIFF
--- a/server/src/apis/quests/dto/create-quest.dto.ts
+++ b/server/src/apis/quests/dto/create-quest.dto.ts
@@ -3,6 +3,7 @@ import {
   CreateSideQuestDto,
   SideQuestRequestDto,
   SideQuestResponseDto,
+  UpdateSideQuestRequestDto,
 } from './create-side-quest.dto';
 import { Difficulty, isHidden, Mode, Status } from '../enums/quest.enum';
 import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
@@ -143,7 +144,25 @@ export class UpdateQuestRequestDto extends OmitType(CreateQuestDto, [
   'status',
   'createdAt',
   'updatedAt',
-]) {}
+]) {
+  @ApiProperty({
+    type: [UpdateSideQuestRequestDto],
+    example: [
+      {
+        id: 1,
+        content: '사이드 퀘스트 1',
+        status: 'ON_PROGRESS',
+      },
+      {
+        id: 2,
+        content: '사이드 퀘스트 2',
+        status: 'ON_PROGRESS',
+      },
+    ],
+    description: '사이드 퀘스트',
+  })
+  public side: UpdateSideQuestRequestDto[];
+}
 
 export class UpdateSubQuestRequestDto extends PickType(CreateQuestDto, ['title', 'hidden']) {}
 

--- a/server/src/apis/quests/dto/create-side-quest.dto.ts
+++ b/server/src/apis/quests/dto/create-side-quest.dto.ts
@@ -5,6 +5,14 @@ import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
 export class CreateSideQuestDto {
   @ApiProperty({
     example: 1,
+    description: '사이드 퀘스트 ID',
+    required: false,
+  })
+  @IsNumber()
+  public id: number;
+
+  @ApiProperty({
+    example: 1,
     description: '메인 퀘스트 ID',
     required: true,
   })

--- a/server/src/apis/quests/dto/create-side-quest.dto.ts
+++ b/server/src/apis/quests/dto/create-side-quest.dto.ts
@@ -70,7 +70,4 @@ export class SideQuestRequestDto extends OmitType(CreateSideQuestDto, [
   'updatedAt',
 ]) {}
 
-export class UpdateSideQuestRequestDto extends PickType(CreateSideQuestDto, [
-  'content',
-  'status',
-]) {}
+export class UpdateSideQuestRequestDto extends PickType(CreateSideQuestDto, ['status']) {}

--- a/server/src/apis/quests/entities/quest.entity.ts
+++ b/server/src/apis/quests/entities/quest.entity.ts
@@ -1,6 +1,6 @@
 import { BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
-import { sideQuest } from './side-quest.entity';
+import { SideQuest } from './side-quest.entity';
 import { Difficulty, isHidden, Mode, Status } from '../enums/quest.enum';
 
 @Entity('quest')
@@ -44,6 +44,6 @@ export class Quest extends BaseEntity {
   })
   user: User;
 
-  @OneToMany(() => sideQuest, (sideQuest) => sideQuest.quest)
-  sideQuests: sideQuest[];
+  @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest)
+  sideQuests: SideQuest[];
 }

--- a/server/src/apis/quests/entities/side-quest.entity.ts
+++ b/server/src/apis/quests/entities/side-quest.entity.ts
@@ -3,7 +3,7 @@ import { Quest } from './quest.entity';
 import { Status } from '../enums/quest.enum';
 
 @Entity('side_quest')
-export class sideQuest extends BaseEntity {
+export class SideQuest extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -20,11 +20,7 @@ import {
   UpdateSubQuestRequestDto,
 } from './dto/create-quest.dto';
 import { UpdateQuestDto } from './dto/update-quest.dto';
-import {
-  CreateSideQuestDto,
-  SideQuestRequestDto,
-  UpdateSideQuestRequestDto,
-} from './dto/create-side-quest.dto';
+import { UpdateSideQuestRequestDto } from './dto/create-side-quest.dto';
 import { UpdateSideQuestDto } from './dto/update-side-quest.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../../common/decorators/auth.decorator';
@@ -129,49 +125,22 @@ export class QuestsController {
   }
 
   @UseGuards(AuthGuard)
-  @Post('side')
-  @ApiOperation({ summary: '사이드 퀘스트 생성' })
-  @ApiBearerAuth('accessToken')
-  @ApiBody({ type: [SideQuestRequestDto] })
-  @ApiCreatedResponse({ description: 'success' })
-  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
-  @HttpCode(HttpStatus.OK)
-  async createSide(@CurrentUser() user: JwtPayload, @Body() createQuestDto: CreateSideQuestDto[]) {
-    return await this.questsService.createSide(user.id, createQuestDto);
-  }
-
-  @UseGuards(AuthGuard)
   @Patch('side/:id')
-  @ApiOperation({ summary: '사이드 퀘스트 개별 수정' })
+  @ApiOperation({ summary: '사이드 퀘스트 상태 수정' })
   @ApiBearerAuth('accessToken')
-  @ApiQuery({ name: 'id', type: Number, description: '퀘스트 ID' })
+  @ApiQuery({ name: 'id', type: Number, description: '사이드 퀘스트 ID' })
   @ApiBody({ type: UpdateSideQuestRequestDto })
   @ApiNoContentResponse({ description: 'success' })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async updateSide(
+  async updateSideStatus(
     @CurrentUser() user: JwtPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateSideQuestDto
   ) {
-    await this.questsService.updateSide(user.id, +id, updateQuestDto);
-  }
-
-  @UseGuards(AuthGuard)
-  @Delete('side/:id')
-  @ApiOperation({ summary: '사이드 퀘스트 개별 삭제' })
-  @ApiBearerAuth('accessToken')
-  @ApiQuery({ name: 'id', type: Number, description: '퀘스트 ID' })
-  @ApiNoContentResponse({ description: 'success' })
-  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  @ApiNotFoundResponse({ description: 'fail - Quests not found' })
-  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
-  @HttpCode(HttpStatus.NO_CONTENT)
-  async removeSide(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
-    await this.questsService.removeSide(user.id, +id);
+    await this.questsService.updateSideStatus(user.id, +id, updateQuestDto);
   }
 
   @UseGuards(AuthGuard)

--- a/server/src/apis/quests/quests.module.ts
+++ b/server/src/apis/quests/quests.module.ts
@@ -3,11 +3,11 @@ import { QuestsService } from './quests.service';
 import { QuestsController } from './quests.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Quest } from './entities/quest.entity';
-import { sideQuest } from './entities/side-quest.entity';
+import { SideQuest } from './entities/side-quest.entity';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Quest, sideQuest]), forwardRef(() => AuthModule)],
+  imports: [TypeOrmModule.forFeature([Quest, SideQuest]), forwardRef(() => AuthModule)],
   controllers: [QuestsController],
   providers: [QuestsService],
 })

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -167,15 +167,8 @@ export class QuestsService {
   async updateSide(userId: number, id: number, updateQuestDto: UpdateSideQuestDto) {
     const currentDate = new Date();
 
-    const quest = await this.questRepository.findOne({
-      where: { userId: userId, id: updateQuestDto.questId },
-    });
-    if (!quest) {
-      throw new HttpException('fail - Quest not found', HttpStatus.NOT_FOUND);
-    }
-
     const targetQuest = await this.sideQuestRepository.findOne({
-      where: { id: id, questId: quest.id },
+      where: { id: id },
     });
     if (!targetQuest) {
       throw new HttpException('fail - Quest not found', HttpStatus.NOT_FOUND);
@@ -185,7 +178,7 @@ export class QuestsService {
       ...updateQuestDto,
       updatedAt: currentDate,
     });
-    await this.questRepository.save(updatedQuest);
+    await this.sideQuestRepository.save(updatedQuest);
   }
 
   async removeSide(userId: number, id: number) {

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -6,14 +6,14 @@ import { UpdateSideQuestDto } from './dto/update-side-quest.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Quest } from './entities/quest.entity';
 import { DataSource, FindManyOptions, Repository } from 'typeorm';
-import { sideQuest } from './entities/side-quest.entity';
+import { SideQuest } from './entities/side-quest.entity';
 import { Difficulty, Mode, Status } from './enums/quest.enum';
 
 @Injectable()
 export class QuestsService {
   constructor(
     @InjectRepository(Quest) private readonly questRepository: Repository<Quest>,
-    @InjectRepository(sideQuest) private readonly sideQuestRepository: Repository<sideQuest>,
+    @InjectRepository(SideQuest) private readonly sideQuestRepository: Repository<SideQuest>,
     private readonly dataSource: DataSource
   ) {}
 
@@ -115,6 +115,13 @@ export class QuestsService {
       updatedAt: currentDate,
     });
     await this.questRepository.save(updatedQuest);
+
+    if (updateQuestDto.side) {
+      for (const it of updateQuestDto.side) {
+        const sideId = it.id;
+        await this.updateSide(userId, sideId, it);
+      }
+    }
   }
 
   async remove(userId: number, id: number) {


### PR DESCRIPTION

### 💡 다음 이슈를 해결했어요.

- 사이드퀘스트 개별 수정 시도 시 수정되지 않는 문제 해결
- 메인 퀘스트 개별 수정에서 사이드 퀘스트 수정이 가능하도록 수정
- 사이드 퀘스트 entity 클래스명 수정
  <br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 사이드퀘스트 수정 메서드에서 `targetQuest` 쿼리 시 where 절 `where: { id: id, questId: quest.id },` -> `where: { id: id },` 로 변경
- 사이드 퀘스트 entity 클래스명 [`sideQuest` -> `SideQuest`] 변경
- 메인 퀘스트 수정 시 사이드 퀘스트가 들어올 때 수정할 수 있도록 변경
```ts
...
if (updateQuestDto.side) {
  for (const it of updateQuestDto.side) {
    const sideId = it.id;
    await this.updateSide(userId, sideId, it);
  }
}
...
```
  <br><br>

### 💡 필요한 후속작업이 있어요.

- API 문서 추가 수정 및 변수 명 변경
- 
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없음)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
