### PR TITLE
[BE] 변수명 알아보기 쉽게 변경

### DIFF
--- a/server/src/apis/quests/dto/create-quest.dto.ts
+++ b/server/src/apis/quests/dto/create-quest.dto.ts
@@ -60,7 +60,8 @@ export class CreateQuestDto {
     required: false,
   })
   @IsArray()
-  public side: CreateSideQuestDto[];
+  @IsNotEmpty()
+  public sideQuests: CreateSideQuestDto[];
 
   @ApiProperty({
     example: '2024-05-15',
@@ -118,7 +119,7 @@ export class CreateQuestDto {
 
 export class CreateQuestRequestDto extends OmitType(CreateQuestDto, [
   'status',
-  'side',
+  'sideQuests',
   'createdAt',
   'updatedAt',
 ]) {
@@ -140,7 +141,7 @@ export class CreateQuestRequestDto extends OmitType(CreateQuestDto, [
 
 export class UpdateQuestRequestDto extends OmitType(CreateQuestDto, [
   'mode',
-  'side',
+  'sideQuests',
   'status',
   'createdAt',
   'updatedAt',

--- a/server/src/apis/quests/dto/create-quest.dto.ts
+++ b/server/src/apis/quests/dto/create-quest.dto.ts
@@ -136,7 +136,7 @@ export class CreateQuestRequestDto extends OmitType(CreateQuestDto, [
     description: '퀘스트 설명 (메인 퀘스트 전용)',
     required: false,
   })
-  public side: Omit<SideQuestRequestDto, 'questId'>[];
+  public sideQuests: Omit<SideQuestRequestDto, 'questId'>[];
 }
 
 export class UpdateQuestRequestDto extends OmitType(CreateQuestDto, [
@@ -162,7 +162,7 @@ export class UpdateQuestRequestDto extends OmitType(CreateQuestDto, [
     ],
     description: '사이드 퀘스트',
   })
-  public side: UpdateSideQuestRequestDto[];
+  public sideQuests: UpdateSideQuestRequestDto[];
 }
 
 export class UpdateSubQuestRequestDto extends PickType(CreateQuestDto, ['title', 'hidden']) {}

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -41,8 +41,8 @@ export class QuestsService {
       const savedQuest = await queryRunner.manager.save(quest);
 
       if (mode === Mode.Main) {
-        for (const it of sideQuests) {
-          const { content } = it;
+        for (const sideQuest of sideQuests) {
+          const { content } = sideQuest;
 
           const side = this.sideQuestRepository.create({
             questId: savedQuest.id,
@@ -126,14 +126,14 @@ export class QuestsService {
       await queryRunner.manager.save(updatedQuest);
 
       if (updateQuestDto.sideQuests) {
-        const deleteSideQuestList = targetSideQuest
-          .filter((it) => !updateQuestDto.sideQuests.some((side) => side.id === it.id))
-          .map((it) => it.id);
+        const deleteSideQuestIdList = targetSideQuest
+          .filter((sideQuest) => !updateQuestDto.sideQuests.some((sideQuestItem) => sideQuestItem.id === sideQuest.id))
+          .map((sideQuest) => sideQuest.id);
         const updateSideQuestList = updateQuestDto.sideQuests.filter((it) => it.id);
 
-        for (const quest of updateSideQuestList) {
+        for (const sideQuest of updateSideQuestList) {
           const targetSideQuest = await this.sideQuestRepository.findOne({
-            where: { id: quest.id },
+            where: { id: sideQuest.id },
           });
           if (!targetSideQuest) {
             throw new HttpException('fail - Quest not found', HttpStatus.NOT_FOUND);
@@ -146,7 +146,7 @@ export class QuestsService {
           await queryRunner.manager.save(updatedQuest);
         }
 
-        for (const sideQuestId of deleteSideQuestList) {
+        for (const sideQuestId of deleteSideQuestIdList) {
           const targetSideQuest = await this.sideQuestRepository.findOne({
             where: { id: sideQuestId },
           });


### PR DESCRIPTION

### 💡 다음 이슈를 해결했어요.

- 기존 코드에서 알아보기 쉽지 않은 변수명 알아보기 쉽게 변경
  <br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- DTO `side` -> `sideQuests` 변경
- `id` 변수를 `userId`와 `questId`로 구분
- `targetQuest` 및 `updatedQuest`를 메인 퀘스트 용과 사이드 퀘스트 용으로 이름 구분

  <br><br>

### 💡 필요한 후속작업이 있어요.

- (없음)
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없음)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
