### PR TITLE
[FE] 메인퀘스트 기능과 스타일링 구현

### DIFF
--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -26,6 +26,11 @@ export const modiMainQuest = async (data: ModifyQuestData) => {
   return response.data;
 };
 
+export const deleteMainQuest = async (id: number) => {
+  const response = await httpClient.delete(API_END_POINT.MAIN_QUEST + `/${id}`);
+  return response.data;
+}
+
 export const getMainQuest = async () => {
   const response = await httpClient.get<Quest[]>(API_END_POINT.MAIN_QUEST);
   return response.data;

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -27,7 +27,7 @@ const MainBox = ({content}: MainBoxProps) => {
   const [checked, setChecked] = useState(Array(sideQuestList.length).fill(false));
   const checkedCount = checked.reduce((count, isChecked) => isChecked ? count + 1 : count, 0);
   const fraction = `${checkedCount} / ${content.sideQuests.length}`;
-
+  
   const handleChangeStatue = () => {
     if (date === formattedCalendar(new Date())) {
       let message = '';
@@ -59,11 +59,13 @@ const MainBox = ({content}: MainBoxProps) => {
 
   const handleNavigate = (event: React.MouseEvent) => {
     event.stopPropagation();
+    if (content.status === 'COMPLETED') return;
     navigate(`/editquest/${content.id}`, { state: { content } });
   }
 
   const handleToggleAccordion = (event: React.MouseEvent) => {
     event.stopPropagation();
+    if (content.status === 'COMPLETED') return;
     setisAccordion(prevState => !prevState);
   }
 
@@ -76,7 +78,9 @@ const MainBox = ({content}: MainBoxProps) => {
           <p className='fDisplay'>{fraction}</p>
         </header>
         <h1 className='title'>{content.title}</h1>
-        <button className='eButton' onClick={handleNavigate}><BsThreeDots /></button>
+        <div>
+          <button className='eButton' onClick={handleNavigate}><BsThreeDots /></button>
+        </div>
       </MainBoxStyle>
       <SideBoxContainer>
       {content && content.sideQuests ? content.sideQuests.map((quest, index) => (

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -57,11 +57,13 @@ const MainBox = ({content}: MainBoxProps) => {
     })
   };
 
-  const handleNavigate = () => {
+  const handleNavigate = (event: React.MouseEvent) => {
+    event.stopPropagation();
     navigate(`/editquest/${content.id}`, { state: { content } });
   }
 
-  const handleToggleAccordion = () => {
+  const handleToggleAccordion = (event: React.MouseEvent) => {
+    event.stopPropagation();
     setisAccordion(prevState => !prevState);
   }
 

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -1,4 +1,4 @@
-import { ModifyQuestStatusProps, createMainQuest, getMainQuest, modiMainQuest, modiQuestStatus, modiSideQuest } from '@/api/quests.api';
+import { ModifyQuestStatusProps, createMainQuest, deleteMainQuest, getMainQuest, modiMainQuest, modiQuestStatus, modiSideQuest } from '@/api/quests.api';
 import { BASE_KEY, QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
 import { Quest, QuestDifficulty, QuestHiddenType, QuestMode, SideContent } from '@/models/quest.model';
@@ -37,17 +37,27 @@ export const useMainQuest = () => {
   const CreateQuestMutation = useMutation({
     mutationFn: createMainQuest,
     onSuccess(res) {
-      // navigate('/');
+      navigate('/');
     },
     onError(err) {
-      // navigate('/error');
+      navigate('/error');
     },
   });
 
   const EditQuestMutation = useMutation({
     mutationFn: modiMainQuest,
     onSuccess(res) {
-      // navigate('/');
+      navigate('/');
+    },
+    onError(err) {
+      navigate('/error');
+    },
+  });
+
+  const DeleteMainQuestsMutation = useMutation({
+    mutationFn: (id: number) => deleteMainQuest(id),
+    onSuccess() {
+      navigate('/');
     },
     onError(err) {
       navigate('/error');
@@ -87,6 +97,7 @@ export const useMainQuest = () => {
     EditQuestMutation,
     modifyMainQuestStatus,
     patchSideMutation,
+    DeleteMainQuestsMutation,
     date,
   }
 };

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -32,7 +32,6 @@ const EditMainQuestQuest = () => {
   const onSubmit = handleSubmit((data) => {
     const hidden = (isPrivate ? 'TRUE' : 'FALSE') as QuestHiddenType;
     const newData = {...data, hidden: hidden};
-    console.log(newData);
     EditQuestMutation.mutate(newData);
   });
 

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -24,7 +24,7 @@ const EditMainQuestQuest = () => {
   const [minusQuest, setMinusQuest] = useState(0);
   const [sideQuests, setSideQuests] = useState(content.sideQuests);
   const [isPrivate, setIsPrivate] = useState(false);
-  const { EditQuestMutation } = useMainQuest();
+  const { EditQuestMutation, DeleteMainQuestsMutation } = useMainQuest();
   const navigate = useNavigate();
 
   const { register, control, handleSubmit } = useForm<EditMainQuestQuestProps>();
@@ -32,6 +32,7 @@ const EditMainQuestQuest = () => {
   const onSubmit = handleSubmit((data) => {
     const hidden = (isPrivate ? 'TRUE' : 'FALSE') as QuestHiddenType;
     const newData = {...data, hidden: hidden};
+    console.log(newData);
     EditQuestMutation.mutate(newData);
   });
 
@@ -75,16 +76,17 @@ const EditMainQuestQuest = () => {
         {content.sideQuests && content.sideQuests.map((sideQuest: SideContent, index:number) => 
           (
             <SideBoxContainer key={index}>
+              <input type='hidden' value={sideQuest.id} {...register(`sideQuests.${index}.id`)} />
               <input 
                 className='checkBoxInput'
                 type='checkbox'             
                 checked={sideQuest.status === 'COMPLETED'}
                 {...register(`sideQuests.${index}.status`)}
                 onChange={(e) => {
-                  const newStatus = e.target.checked ? 'COMPLETED' : 'ON_PROGRESS';
+                  const newStatus = e.target.checked ? 'COMPLETED' : 'ON_PROGRESS';              
                   const newSideQuests = [...sideQuests];
                   newSideQuests[index].status = newStatus;
-                  setSideQuests(newSideQuests);
+                  setSideQuests(newSideQuests);                  
                 }}
               />
               <QuestInputBox  
@@ -124,7 +126,9 @@ const EditMainQuestQuest = () => {
         </div>
         <div className='modifiyAndClose'>
           <Button className='modifiyButton' type={'submit'} children={'수정'} size={'medium'} color={'black'} />
-          <Button className='closeButton' children={'닫기'} size={'medium'} color={'black'} onClick={() => navigate('/')} />  
+          <Button className='closeButton' children={'삭제'} size={'medium'} color={'black'} onClick={() => {
+              DeleteMainQuestsMutation.mutate(content.id);
+            }} />  
         </div>
       </form>
     </EditMainQuestQuestStyle>

--- a/client/src/styles/globalstyles.ts
+++ b/client/src/styles/globalstyles.ts
@@ -25,7 +25,7 @@ export const GlobalStyle = createGlobalStyle`
       color: inherit;
       font: inherit;
       margin: 0;
-      background: #fff;
+      background: inherit;
       border: none;
       box-shadow: none;
   }


### PR DESCRIPTION
Closes #120

### 💡 다음 이슈를 해결했어요.
- [x] 메인 퀘스트 삭제 기능 추가
- [x] 메인 퀘스트 박스 이벤트 버블링 현상 수정
- [x] 메인 퀘스트 박스 완료 시 스타일링 수정
- [x] 메인 퀘스트 완료 시 사이드 퀘스트 수정 불가 구현 

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ 메인 퀘스트 삭제 기능 추가
```ts
// quests.api.ts
export const deleteMainQuest = async (id: number) => {
  const response = await httpClient.delete(API_END_POINT.MAIN_QUEST + `/${id}`);
  return response.data;
}
```ts
// useMainQuest.ts
const DeleteMainQuestsMutation = useMutation({
    mutationFn: (id: number) => deleteMainQuest(id),
    onSuccess() {
      navigate('/');
    },
    onError(err) {
      navigate('/error');
```
<img width="477" alt="스크린샷 2024-05-19 오후 8 50 00" src="https://github.com/ingame-app/ingame/assets/89385423/14cad08c-6d20-4ff7-ae46-cc6f353ef763">
<img width="423" alt="스크린샷 2024-05-19 오후 8 50 08" src="https://github.com/ingame-app/ingame/assets/89385423/59a20051-9b01-40d4-b56e-dec9e208efb6">
<img width="468" alt="스크린샷 2024-05-19 오후 8 50 17" src="https://github.com/ingame-app/ingame/assets/89385423/81e0f899-24ce-4ec8-a0fb-5775c8801eaa">


#### 🛠️ 메인 퀘스트 박스 이벤트 버블링 현상 수정, 메인 퀘스트 완료 시 사이드 퀘스트 수정 불가 구현 
```tsx
// MainBox.tsx
const handleNavigate = (event: React.MouseEvent) => {
    event.stopPropagation();
    if (content.status === 'COMPLETED') return;
    navigate(`/editquest/${content.id}`, { state: { content } });
  }

  const handleToggleAccordion = (event: React.MouseEvent) => {
    event.stopPropagation();
    if (content.status === 'COMPLETED') return;
    setisAccordion(prevState => !prevState);
  }
```

#### 🛠️ 메인퀘스트 박스 완료 시 스타일링 수정
<img width="474" alt="스크린샷 2024-05-19 오후 8 54 37" src="https://github.com/ingame-app/ingame/assets/89385423/b167bcfc-3f70-4b64-b2b5-e7bf6fdde786">


### 💡 필요한 후속작업이 있어요.

- [ ] 메인 퀘스트 수정 페이지 스타일링과 기능 

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
