### PR TITLE
[BE] 퀘스트 API 버그 수정

### DIFF
--- a/server/src/apis/quests/entities/quest.entity.ts
+++ b/server/src/apis/quests/entities/quest.entity.ts
@@ -20,11 +20,11 @@ export class Quest extends BaseEntity {
   @Column({ type: 'enum', name: 'mode', enum: Mode })
   mode!: Mode;
 
-  @Column('timestamp', { nullable: false })
-  startDate: Date;
+  @Column('date', { nullable: false })
+  startDate: string;
 
-  @Column('timestamp', { nullable: true })
-  endDate: Date;
+  @Column('date', { nullable: true })
+  endDate: string;
 
   @Column({ type: 'enum', name: 'hidden', enum: isHidden })
   hidden!: isHidden;

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -154,8 +154,8 @@ export class QuestsController {
   @HttpCode(HttpStatus.OK)
   async findAllSub(@CurrentUser() user: JwtPayload, @Query('date') query: string) {
     const queryDate = query
-      ? new Date(query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3 00:00:00'))
-      : new Date();
+      ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
+      : new Date().toISOString().replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
     return await this.questsService.findAll(user.id, Mode.Sub, queryDate);
   }
 

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -120,7 +120,11 @@ export class QuestsService {
       }
 
       const updatedQuest = this.questRepository.merge(targetQuest, {
-        ...updateQuestDto,
+        difficulty: updateQuestDto.difficulty,
+        title: updateQuestDto.title,
+        startDate: updateQuestDto.startDate,
+        endDate: updateQuestDto.endDate,
+        hidden: updateQuestDto.hidden,
         updatedAt: currentDate,
       });
       await queryRunner.manager.save(updatedQuest);
@@ -136,14 +140,16 @@ export class QuestsService {
 
         for (const sideQuest of updateSideQuestList) {
           const targetSideQuest = await this.sideQuestRepository.findOne({
-            where: { id: sideQuest.id },
+            where: { id: sideQuest.id, questId: questId },
           });
           if (!targetSideQuest) {
             throw new HttpException('fail - Quest not found', HttpStatus.NOT_FOUND);
           }
 
           const updatedQuest = this.sideQuestRepository.merge(targetSideQuest, {
-            ...updateQuestDto,
+            id: sideQuest.id,
+            content: sideQuest.content,
+            status: sideQuest.status,
             updatedAt: currentDate,
           });
           await queryRunner.manager.save(updatedQuest);

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -67,7 +67,7 @@ export class QuestsService {
     return { message: 'success' };
   }
 
-  async findAll(userId: number, mode: Mode, queryDate?: Date) {
+  async findAll(userId: number, mode: Mode, queryDate?: string) {
     const mainOptions: FindManyOptions<Quest> = {
       where: { userId: userId, mode: Mode.Main },
       order: {
@@ -127,7 +127,10 @@ export class QuestsService {
 
       if (updateQuestDto.sideQuests) {
         const deleteSideQuestIdList = targetSideQuest
-          .filter((sideQuest) => !updateQuestDto.sideQuests.some((sideQuestItem) => sideQuestItem.id === sideQuest.id))
+          .filter(
+            (sideQuest) =>
+              !updateQuestDto.sideQuests.some((sideQuestItem) => sideQuestItem.id === sideQuest.id)
+          )
           .map((sideQuest) => sideQuest.id);
         const updateSideQuestList = updateQuestDto.sideQuests.filter((it) => it.id);
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 퀘스트 시작 / 종료일의 입출력 형태를 `yyyy-mm-dd` 형태로 변경
- FE에서 퀘스트 업데이트 시 409 Conflict 오류 출력 문제 해결
  <br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 퀘스트 entity의 `startDate`, `endDate`의 타입을 `timestamp`에서 `date`로 변경
- 쿼리 시 conflict 문제 해결을 위해 `UpdateQuestDto`의 항목 전개 (`...updateQuestDto` -> 모든 속성 전개)
  <br><br>

### 💡 필요한 후속작업이 있어요.

- (없음)
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없음)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
