### PR TITLE
[FE] 닉네임이 길어질 시, 줄임표로 표현되도록 스타일 수정

### DIFF
--- a/client/src/components/UserProfile/UserProfile.tsx
+++ b/client/src/components/UserProfile/UserProfile.tsx
@@ -72,6 +72,8 @@ const UserDetailInfoStyle = styled.div`
     .nickname {
       width: 100%;
       white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- [x] 닉네임이 길어지는 경우, 줄임표로 표시되도록 스타일을 추가

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
기존에는 닉네임이 길어지는 경우 반응형이 깨지는 문제가 발생했습니다. 이를 해결하기 위해 닉네임이 길어지면
줄임표로 표시되도록 스타일 속성을 추가했습니다.

```tsx
<div className="basic__info">
    <p className="nickname">
        Lv {userInfo.level}. {userInfo.nickname}
    </p>
    <EditProfileButton nickname={userInfo.nickname} intro={userInfo.intro} />
</div>

const UserDetailInfoStyle = styled.div`
  ...
  .basic__info {
    display: flex;
    justify-content: space-between;
    align-items: center;
    padding-left: 0.3rem;
    gap: 1rem;
    width: 100%;

    .nickname {
      width: 100%;
      white-space: nowrap;
      overflow: hidden;
      text-overflow: ellipsis;
    }
  }
`
```

### ✅ 셀프 체크리스트
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
