### PR TITLE
[BE] refresh token 기능 구현 완료

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@nestjs-modules/ioredis": "^2.0.2",
         "@nestjs/common": "^10.3.2",
         "@nestjs/config": "^3.2.2",
         "@nestjs/core": "^10.3.2",
@@ -25,6 +26,7 @@
         "cookie-parser": "^1.4.6",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.5",
+        "ioredis": "^5.4.1",
         "mysql2": "^3.9.7",
         "nest-winston": "^1.9.4",
         "reflect-metadata": "^0.2.1",
@@ -1067,6 +1069,11 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1697,6 +1704,19 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/@nestjs-modules/ioredis": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs-modules/ioredis/-/ioredis-2.0.2.tgz",
+      "integrity": "sha512-8pzSvT8R3XP6p8ZzQmEN8OnY0yWrJ/elFhwQK+PID2zf1SLBkAZ18bDcx3SKQ2atledt0gd9kBeP5xT4MlyS7Q==",
+      "optionalDependencies": {
+        "@nestjs/terminus": "10.2.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": ">=6.7.0",
+        "@nestjs/core": ">=6.7.0",
+        "ioredis": ">=5.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.3.1.tgz",
@@ -2067,6 +2087,76 @@
           "optional": true
         },
         "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/terminus": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-10.2.0.tgz",
+      "integrity": "sha512-zPs98xvJ4ogEimRQOz8eU90mb7z+W/kd/mL4peOgrJ/VqER+ibN2Cboj65uJZW3XuNhpOqaeYOJte86InJd44A==",
+      "optional": true,
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^1.0.0 || ^2.0.0 || ^3.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "@nestjs/microservices": "^9.0.0 || ^10.0.0",
+        "@nestjs/mongoose": "^9.0.0 || ^10.0.0",
+        "@nestjs/sequelize": "^9.0.0 || ^10.0.0",
+        "@nestjs/typeorm": "^9.0.0 || ^10.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
           "optional": true
         }
       }
@@ -3388,6 +3478,15 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -3907,6 +4006,57 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "optional": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4161,6 +4311,15 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4239,6 +4398,18 @@
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
         "validator": "^13.9.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -4408,6 +4579,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -6544,6 +6723,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7633,10 +7835,20 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -8985,6 +9197,25 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
@@ -9603,6 +9834,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -10343,7 +10579,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -10849,6 +11085,18 @@
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "typeorm:d": "cross-env NODE_ENV=production node -r ts-node/register ./node_modules/typeorm/cli.js -d src/common/config/datasource.config.ts"
   },
   "dependencies": {
+    "@nestjs-modules/ioredis": "^2.0.2",
     "@nestjs/common": "^10.3.2",
     "@nestjs/config": "^3.2.2",
     "@nestjs/core": "^10.3.2",
@@ -40,6 +41,7 @@
     "cookie-parser": "^1.4.6",
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.5",
+    "ioredis": "^5.4.1",
     "mysql2": "^3.9.7",
     "nest-winston": "^1.9.4",
     "reflect-metadata": "^0.2.1",

--- a/server/src/apis/auth/auth.controller.ts
+++ b/server/src/apis/auth/auth.controller.ts
@@ -24,6 +24,8 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { AccessTokenPayload } from './auth.interface';
+import { CurrentUser } from 'src/common/decorators/auth.decorator';
 
 @Controller('auth')
 @ApiTags('Auth API')
@@ -56,7 +58,8 @@ export class AuthController {
   @ApiOkResponse({ description: '로그아웃 성공 시 쿠키의 토큰 삭제' })
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'fail - Invaild token' })
-  async logout(@Res() res: Response) {
+  async logout(@CurrentUser() user: AccessTokenPayload, @Res() res: Response) {
+    await this.authService.logout(user.id);
     res.clearCookie('refreshToken');
     res.sendStatus(HttpStatus.NO_CONTENT);
   }

--- a/server/src/apis/auth/auth.controller.ts
+++ b/server/src/apis/auth/auth.controller.ts
@@ -5,13 +5,15 @@ import {
   HttpStatus,
   HttpCode,
   Res,
+  Req,
   UseGuards,
   UsePipes,
   ValidationPipe,
+  HttpException,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginUserDto } from './dto/login-user.dto';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { AuthGuard } from './auth.guard';
 import {
   ApiBearerAuth,
@@ -35,14 +37,16 @@ export class AuthController {
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.OK)
   async login(@Body() loginUserDto: LoginUserDto, @Res() res: Response) {
-    const acceccToken = await this.authService.login(loginUserDto);
+    const isProduction = process.env.NODE_ENV === 'production';
+    const { accessToken, refreshToken } = await this.authService.login(loginUserDto);
 
-    res.cookie('accessToken', acceccToken, {
+    res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
       maxAge: 1000 * 60 * 60 * 24 * 7,
+      sameSite: isProduction ? 'none' : 'lax',
+      secure: isProduction,
     });
-
-    res.json(acceccToken);
+    res.json(accessToken);
   }
 
   @UseGuards(AuthGuard)
@@ -53,7 +57,26 @@ export class AuthController {
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'fail - Invaild token' })
   async logout(@Res() res: Response) {
-    res.clearCookie('accessToken');
+    res.clearCookie('refreshToken');
     res.sendStatus(HttpStatus.NO_CONTENT);
+  }
+
+  @Post('token')
+  @HttpCode(HttpStatus.OK)
+  async refreshToken(@Req() req: Request, @Res() res: Response) {
+    const isProduction = process.env.NODE_ENV === 'production';
+    const refreshToken: string = req.cookies.refreshToken;
+    if (!refreshToken) {
+      throw new HttpException('Refresh token not found', HttpStatus.UNAUTHORIZED);
+    }
+    const { newAccessToken, newRefreshToken } = await this.authService.refresh(refreshToken);
+
+    res.cookie('refreshToken', newRefreshToken, {
+      httpOnly: true,
+      maxAge: 1000 * 60 * 60 * 24 * 7,
+      sameSite: isProduction ? 'none' : 'lax',
+      secure: isProduction,
+    });
+    res.json(newAccessToken);
   }
 }

--- a/server/src/apis/auth/auth.guard.ts
+++ b/server/src/apis/auth/auth.guard.ts
@@ -2,7 +2,7 @@ import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
-import { JwtPayload } from './auth.interface';
+import { AccessTokenPayload } from './auth.interface';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -18,7 +18,7 @@ export class AuthGuard implements CanActivate {
     }
     try {
       const secretKey = this.configService.get<string>('SECRET_KEY');
-      const payload: JwtPayload = await this.jwtService.verifyAsync(acceccToken, {
+      const payload: AccessTokenPayload = await this.jwtService.verifyAsync(acceccToken, {
         secret: secretKey,
       });
       request['user'] = payload;

--- a/server/src/apis/auth/auth.interface.ts
+++ b/server/src/apis/auth/auth.interface.ts
@@ -1,4 +1,8 @@
-export interface JwtPayload {
+export interface AccessTokenPayload {
   id: number;
   email: string;
+}
+
+export interface RefreshTokenPayload {
+  id: number;
 }

--- a/server/src/apis/auth/auth.service.ts
+++ b/server/src/apis/auth/auth.service.ts
@@ -35,6 +35,10 @@ export class AuthService {
     return { accessToken, refreshToken };
   }
 
+  async logout(id: number): Promise<void> {
+    await this.redis.del(`refreshToken:${id}`);
+  }
+
   async refresh(refreshToken: string) {
     const secretKey = this.configService.get<string>('REFRESH_TOKEN_SECRET_KEY');
     try {

--- a/server/src/apis/auth/auth.service.ts
+++ b/server/src/apis/auth/auth.service.ts
@@ -66,4 +66,18 @@ export class AuthService {
       expiresIn: this.configService.get<string>('REFRESH_TOKEN_EXPIRES_IN'),
     });
   }
+
+  private async encryptRefreshToken(refreshToken: string): Promise<string> {
+    const saltRounds = parseInt(this.configService.get<string>('SALT_ROUNDS'));
+    const salt = await bcrypt.genSalt(saltRounds);
+
+    return await bcrypt.hash(refreshToken, salt);
+  }
+
+  private async verifyRefreshToken(
+    refreshToken: string,
+    hasedRefreshToken: string
+  ): Promise<boolean> {
+    return bcrypt.compare(refreshToken, hasedRefreshToken);
+  }
 }

--- a/server/src/apis/point/point.controller.ts
+++ b/server/src/apis/point/point.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { PointService } from './point.service';
 import { AuthGuard } from '../auth/auth.guard';
-import { JwtPayload } from '../auth/auth.interface';
+import { AccessTokenPayload } from '../auth/auth.interface';
 import { UpdatePointDto } from './dto/update-point.dto';
 import { CurrentUser } from 'src/common/decorators/auth.decorator';
 import {
@@ -35,7 +35,10 @@ export class PointController {
   @ApiNotFoundResponse({ description: 'fail - Quest not found' })
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
-  async updatePoint(@CurrentUser() user: JwtPayload, @Body() updatePointDto: UpdatePointDto) {
+  async updatePoint(
+    @CurrentUser() user: AccessTokenPayload,
+    @Body() updatePointDto: UpdatePointDto
+  ) {
     await this.pointService.updatePoint(user.id, updatePointDto);
   }
 }

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -24,7 +24,7 @@ import { UpdateSideQuestRequestDto } from './dto/create-side-quest.dto';
 import { UpdateSideQuestDto } from './dto/update-side-quest.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../../common/decorators/auth.decorator';
-import { JwtPayload } from '../auth/auth.interface';
+import { AccessTokenPayload } from '../auth/auth.interface';
 import { Mode } from './enums/quest.enum';
 import {
   ApiBearerAuth,
@@ -55,7 +55,7 @@ export class QuestsController {
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.CREATED)
-  async create(@CurrentUser() user: JwtPayload, @Body() createQuestDto: CreateQuestDto) {
+  async create(@CurrentUser() user: AccessTokenPayload, @Body() createQuestDto: CreateQuestDto) {
     return await this.questsService.create(user.id, createQuestDto);
   }
 
@@ -71,7 +71,7 @@ export class QuestsController {
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateStatus(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: AccessTokenPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateQuestDto
   ) {
@@ -87,7 +87,7 @@ export class QuestsController {
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.OK)
-  async findAll(@CurrentUser() user: JwtPayload) {
+  async findAll(@CurrentUser() user: AccessTokenPayload) {
     return await this.questsService.findAll(user.id, Mode.Main);
   }
 
@@ -103,7 +103,7 @@ export class QuestsController {
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async update(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: AccessTokenPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateQuestDto
   ) {
@@ -120,7 +120,7 @@ export class QuestsController {
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async remove(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
+  async remove(@CurrentUser() user: AccessTokenPayload, @Param('id') id: string) {
     await this.questsService.remove(user.id, +id);
   }
 
@@ -136,7 +136,7 @@ export class QuestsController {
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateSideStatus(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: AccessTokenPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateSideQuestDto
   ) {
@@ -152,7 +152,7 @@ export class QuestsController {
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.OK)
-  async findAllSub(@CurrentUser() user: JwtPayload, @Query('date') query: string) {
+  async findAllSub(@CurrentUser() user: AccessTokenPayload, @Query('date') query: string) {
     const queryDate = query
       ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
       : new Date().toISOString().replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
@@ -171,7 +171,7 @@ export class QuestsController {
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateSub(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: AccessTokenPayload,
     @Param('id') id: string,
     @Body() updateQuestDto: UpdateQuestDto
   ) {
@@ -188,7 +188,7 @@ export class QuestsController {
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async removeSub(@CurrentUser() user: JwtPayload, @Param('id') id: string) {
+  async removeSub(@CurrentUser() user: AccessTokenPayload, @Param('id') id: string) {
     await this.questsService.remove(user.id, +id);
   }
 }

--- a/server/src/apis/users/users.controller.ts
+++ b/server/src/apis/users/users.controller.ts
@@ -18,7 +18,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from 'src/common/decorators/auth.decorator';
-import { JwtPayload } from '../auth/auth.interface';
+import { AccessTokenPayload } from '../auth/auth.interface';
 import { ProfilePhotoDto } from './dto/profile-photo.dto';
 import {
   ApiBearerAuth,
@@ -60,7 +60,7 @@ export class UsersController {
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.NO_CONTENT)
-  async deleteUser(@CurrentUser() user: JwtPayload) {
+  async deleteUser(@CurrentUser() user: AccessTokenPayload) {
     await this.usersService.deleteCurrentUserById(user.id);
   }
 
@@ -72,7 +72,7 @@ export class UsersController {
   @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
   @ApiForbiddenResponse({ description: 'Fail - Invalid token' })
   @HttpCode(HttpStatus.OK)
-  async getCurrentUser(@CurrentUser() user: JwtPayload): Promise<UserProfileDto> {
+  async getCurrentUser(@CurrentUser() user: AccessTokenPayload): Promise<UserProfileDto> {
     return await this.usersService.getUserById(user.id);
   }
 
@@ -86,7 +86,10 @@ export class UsersController {
   @ApiConflictResponse({ description: '닉네임이 이미 사용 중입니다' })
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
-  async updateUserInfo(@CurrentUser() user: JwtPayload, @Body() updateUserDto: UpdateUserDto) {
+  async updateUserInfo(
+    @CurrentUser() user: AccessTokenPayload,
+    @Body() updateUserDto: UpdateUserDto
+  ) {
     await this.usersService.updateCurrenUserInfoById(user.id, updateUserDto);
   }
 
@@ -100,7 +103,7 @@ export class UsersController {
   @UsePipes(ValidationPipe)
   @HttpCode(HttpStatus.NO_CONTENT)
   async updateProfilePhoto(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: AccessTokenPayload,
     @Body() profilePhotoDto: ProfilePhotoDto
   ) {
     await this.usersService.updateProfilePhotoById(user.id, profilePhotoDto);

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -15,6 +15,8 @@ import { SchedulerService } from './common/scheduler/scheduler.service';
 import { SchedulerModule } from './common/scheduler/scheduler.module';
 import { LevelCalculatorModule } from './common/level-calculator/level-calculator.module';
 import { PointModule } from './apis/point/point.module';
+import { RedisModule } from '@nestjs-modules/ioredis';
+import { redisConfig } from './common/config/redis.config';
 
 @Module({
   imports: [
@@ -26,6 +28,10 @@ import { PointModule } from './apis/point/point.module';
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => typeORMConfig(configService),
+    }),
+    RedisModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => redisConfig(configService),
     }),
     WinstonLoggerModule,
     SchedulerModule,

--- a/server/src/common/config/jwt.config.ts
+++ b/server/src/common/config/jwt.config.ts
@@ -2,7 +2,7 @@ import { ConfigService } from '@nestjs/config';
 
 export const JwtConfig = async (configService: ConfigService) => {
   return {
-    secret: configService.get<string>('SECRET_KEY'),
-    signOptions: { expiresIn: configService.get<string>('EXPIRES_IN') },
+    secret: configService.get<string>('ACCESS_TOKEN_SECRET_KEY'),
+    signOptions: { expiresIn: configService.get<string>('ACCESS_TOKEN_EXPIRES_IN') },
   };
 };

--- a/server/src/common/config/redis.config.ts
+++ b/server/src/common/config/redis.config.ts
@@ -1,0 +1,15 @@
+import { RedisModuleOptions } from '@nestjs-modules/ioredis';
+import { ConfigService } from '@nestjs/config';
+import { RedisOptions } from 'ioredis';
+
+export const redisConfig = (configService: ConfigService): RedisModuleOptions => {
+  const redisOptions: RedisOptions = {
+    host: configService.get<string>('REDIS_HOST'),
+    port: parseInt(configService.get<string>('REDIS_PORT')),
+  };
+
+  return {
+    type: 'single',
+    options: redisOptions,
+  };
+};

--- a/server/src/common/filters/all-exception.filter.ts
+++ b/server/src/common/filters/all-exception.filter.ts
@@ -6,18 +6,13 @@ import { WinstonLoggerService } from '../logger/winston-logger.service';
 @Catch()
 export class AllExceptionFilter implements ExceptionFilter {
   constructor(private readonly logger: WinstonLoggerService) {}
-
   catch(exception: unknown, host: ArgumentsHost): void {
-    let message: string = 'UNKNOWN ERROR';
-
     const ctx = host.switchToHttp();
     const res = ctx.getResponse<Response>();
     const req = ctx.getRequest<Request>();
     const statusCode = this.getHttpStatus(exception);
     const datetime = new Date();
-
-    message = exception instanceof HttpException ? exception.message : message;
-    message = exception instanceof QueryFailedError ? 'Query Fail Error' : message;
+    const message = this.getErrorMessage(exception);
 
     const errorResponse = {
       statusCode,
@@ -43,6 +38,18 @@ export class AllExceptionFilter implements ExceptionFilter {
       return exception.getStatus();
     } else {
       return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+  }
+
+  private getErrorMessage(exception: unknown): string {
+    if (exception instanceof HttpException) {
+      return exception.message;
+    } else if (exception instanceof QueryFailedError) {
+      return 'Query Failed Error';
+    } else if (exception instanceof Error) {
+      return exception.message;
+    } else {
+      return 'UNKNOWN ERROR';
     }
   }
 }


### PR DESCRIPTION

<strong>
Closes #128 
</strong>


### 💡 다음 이슈를 해결했어요.

- access token과 함께 refresh token 발급
- token 갱신 api 추가
- refresh token redis에 저장 후 토큰 갱신 시 검증
- 로그아웃 시 refresh token 삭제
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### refresh token 추가
- access token은 response body로 보내주기
- refresh token은 cookie 안에 할당
- refresh token bcrypt로 암호화하여 redis에 넣기
```ts
// auth.controller.ts
  @Post('login')
  @ApiOperation({ summary: '로그인' })
  @ApiOkResponse({ description: '로그인 성공 시 토큰 반환' })
  @ApiNotFoundResponse({ description: 'fail- User not found' })
  @UsePipes(ValidationPipe)
  @HttpCode(HttpStatus.OK)
  async login(@Body() loginUserDto: LoginUserDto, @Res() res: Response) {
    const isProduction = process.env.NODE_ENV === 'production';
    const { accessToken, refreshToken } = await this.authService.login(loginUserDto);

    res.cookie('refreshToken', refreshToken, {
      httpOnly: true,
      maxAge: 1000 * 60 * 60 * 24 * 7,
      sameSite: isProduction ? 'none' : 'lax',
      secure: isProduction,
    });
    res.json(accessToken);
  }

// auth.service.ts
  async login(loginUserDto: LoginUserDto) {
    const { email, password } = loginUserDto;
    const user = await this.usersService.getUserByEmail(email);
    const verifyPassword = await bcrypt.compare(password, user.password);

    if (!user || !verifyPassword) {
      throw new UnauthorizedException();
    }

    const accessToken = await this.generateAccessToken(user);
    const refreshToken = await this.generateRefreshToken(user.id);
    const hasedRefreshToken = await this.encryptRefreshToken(refreshToken);
    await this.redis.set(`refreshToken:${user.id}`, hasedRefreshToken, 'EX', 60 * 60 * 24 * 7);

    return { accessToken, refreshToken };
  }
```

#### token 갱신 api 추가
- cookie로부터 refresh token 가져오기
- redis에 저장되어 있는 refresh token 가져오기
- 암호화된 refresh token hash 후 cookie의 refresh token과 비교하기
- true라면, 새로운 access token과 refresh token 생성하기
- redis의 refresh token 교체하기
- access token은 response body 값으로 보내주고, refresh token은 cookie에 담아주기
```ts
// auth.controller.ts
  @Post('token')
  @HttpCode(HttpStatus.OK)
  async refreshToken(@Req() req: Request, @Res() res: Response) {
    const isProduction = process.env.NODE_ENV === 'production';
    const refreshToken: string = req.cookies.refreshToken;
    if (!refreshToken) {
      throw new HttpException('Refresh token not found', HttpStatus.UNAUTHORIZED);
    }
    const { newAccessToken, newRefreshToken } = await this.authService.refresh(refreshToken);

    res.cookie('refreshToken', newRefreshToken, {
      httpOnly: true,
      maxAge: 1000 * 60 * 60 * 24 * 7,
      sameSite: isProduction ? 'none' : 'lax',
      secure: isProduction,
    });
    res.json(newAccessToken);
  }

// auth.service.ts
  async refresh(refreshToken: string) {
    const secretKey = this.configService.get<string>('REFRESH_TOKEN_SECRET_KEY');
    try {
      const decodedToken: RefreshTokenPayload = this.jwtService.verify(refreshToken, {
        secret: secretKey,
      });
      const user = await this.usersService.getUserById(decodedToken.id);
      if (!user) {
        throw new UnauthorizedException();
      }

      const storedHashedToken = await this.redis.get(`refreshToken:${user.id}`);
      const isValid = await this.verifyRefreshToken(refreshToken, storedHashedToken);
      if (!isValid) {
        throw new UnauthorizedException();
      }

      const newAccessToken = await this.generateAccessToken(user);
      const newRefreshToken = await this.generateRefreshToken(user.id);

      const newHashedRefreshToken = await this.encryptRefreshToken(newRefreshToken);
      await this.redis.set(
        `refreshToken:${user.id}`,
        newHashedRefreshToken,
        'EX',
        60 * 60 * 24 * 7
      );

      return { newAccessToken, newRefreshToken };
    } catch {
      throw new UnauthorizedException();
    }
  }
```
#### 로그아웃 시 refresh token 삭제
- cookie에서 refresh token 삭제
- redis 저장소에서 userId에 해당하는 refresh token 삭제
```ts
// auth.controller.ts
 @UseGuards(AuthGuard)
  @Post('logout')
  @ApiOperation({ summary: '로그아웃' })
  @ApiBearerAuth('accessToken')
  @ApiOkResponse({ description: '로그아웃 성공 시 쿠키의 토큰 삭제' })
  @ApiUnauthorizedResponse({ description: 'Unauthenticated' })
  @ApiForbiddenResponse({ description: 'fail - Invaild token' })
  async logout(@CurrentUser() user: AccessTokenPayload, @Res() res: Response) {
    await this.authService.logout(user.id);
    res.clearCookie('refreshToken');
    res.sendStatus(HttpStatus.NO_CONTENT);
  }

// auth.service.ts
  async logout(id: number): Promise<void> {
    await this.redis.del(`refreshToken:${id}`);
  }
```
#### redis 저장소 환경 설정
- 간편하게 사용할 수 있는 @node-module/ioredis 사용
- app.module에 동적으로 환경 변수 설정
```ts
// redis.config.ts
import { RedisModuleOptions } from '@nestjs-modules/ioredis';
import { ConfigService } from '@nestjs/config';
import { RedisOptions } from 'ioredis';

export const redisConfig = (configService: ConfigService): RedisModuleOptions => {
  const redisOptions: RedisOptions = {
    host: configService.get<string>('REDIS_HOST'),
    port: parseInt(configService.get<string>('REDIS_PORT')),
  };

  return {
    type: 'single',
    options: redisOptions,
  };
};

// app.module.ts
    RedisModule.forRootAsync({
      inject: [ConfigService],
      useFactory: (configService: ConfigService) => redisConfig(configService),
    }),
```

#### redis 사용 방법
- docker-compose.yml 파일 생성
- docker-compose.yml 파일이 존재하는 폴더에서 docker-compose up -d 입력
- docker ps 명령어로 컨테이너 제대로 실행중인지 확인하기
```yml
// docker-compose.yml
version: '3.8'

services:
  redis:
    image: redis:latest
    ports:
      - "6379:6379"
```
```shall
docker-compose up -d
docker ps
```

#### redis 명령어
- redis cli를 통해 컨테이너의 레디스에 접속
```shall
docker exec -it [docker ps로 나온 container id] redis-cli
KEYS * // 전체 key 조회
GET "refreshToken:[userId]" // key값에 해당하는 값 가져오기
DEL "refreshToken:[userId]" // 해당하는 key 삭제
```
### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
