### PR TITLE
[FE] 랭킹페이지 무한스크롤, 메인화면의 사이드퀘스트 값 버그 수정

### DIFF
--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -36,8 +36,8 @@ export const getMainQuest = async () => {
   return response.data;
 };
 
-export const modiSideQuest = async (param: number) => {
-  const response = await httpClient.patch(API_END_POINT.SIDE_QUEST + `/${param}`);
+export const modiSideQuest = async (param: number, status: QuestStatus) => {
+  const response = await httpClient.patch(API_END_POINT.SIDE_QUEST + `/${param}`, { status });
   return response.data;
 };
 

--- a/client/src/api/ranking.api.ts
+++ b/client/src/api/ranking.api.ts
@@ -6,6 +6,9 @@ import { httpClient } from '@/utils/axios';
 //   pageParam: number;
 //   rankingPerPage: number;
 // }
+// { pageParam, rankingPerPage }
+// ?pageParam=${pageParam}&rankingPerPage=${rankingPerPage} query string값이고
+// query parameter로 넘겨주는 값이다 { pageParam, rankingPerPage }
 
 export const getRanking = async (): Promise<RankingItem[]> => {
   try {

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -6,7 +6,6 @@ interface BottonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size: Buttonsize;
   disabled?: boolean;
   color: string;
-  isActive?: string;
 }
 
 const Button: React.FC<BottonProps> = ({

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { BsThreeDots } from 'react-icons/bs';
 import { MdArrowDropDown } from 'react-icons/md';
 import { MdArrowDropUp } from 'react-icons/md';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { sideQuestList } from '@/shared/dummy';
 import SideBox from './SideBox';
 import { Quest, QuestStatus, SideContent } from '@/models/quest.model';
@@ -115,8 +115,7 @@ const MainBox = ({ content }: MainBoxProps) => {
               }
             }}
             content={quest.content}
-/>
-              ) : null
+            />) : null
             )
           ) : (
             <div>내용이 없습니다.</div>
@@ -187,7 +186,7 @@ const SideBoxContainer = styled.div`
   align-items: flex-end;
   width: 90%;
   gap: 5px;
-  margin-right: 11.7%;
+  margin-left: 9.5%;
 `;
 
 export default MainBox;

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { BsThreeDots } from 'react-icons/bs';
 import { MdArrowDropDown } from 'react-icons/md';
 import { MdArrowDropUp } from 'react-icons/md';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { sideQuestList } from '@/shared/dummy';
 import SideBox from './SideBox';
 import { Quest, QuestStatus, SideContent } from '@/models/quest.model';
@@ -25,9 +25,8 @@ const MainBox = ({ content }: MainBoxProps) => {
   const navigate = useNavigate();
   const [isAccordion, setisAccordion] = useState(false);
   const [checked, setChecked] = useState(Array(sideQuestList.length).fill(false));
-  const checkedCount = checked.reduce((count, isChecked) => (isChecked ? count + 1 : count), 0);
-  const fraction = `${checkedCount} / ${content.sideQuests.length}`;
-  
+  const [sideQuests, setSideQuests] = useState(content.sideQuests);
+  const fraction = `${sideQuests.filter((item) => item.status === 'COMPLETED').length} / ${content.sideQuests.length}`;
   const handleChangeStatue = () => {
     if (date === formattedDate(new Date())) {
       let message = '';
@@ -94,15 +93,29 @@ const MainBox = ({ content }: MainBoxProps) => {
                 <SideBox
                   key={index}
                   isAccordion={isAccordion}
-                  checked={checked[index]}
+                  checked={sideQuests[index].status === 'COMPLETED'}
                   onClick={() => {
-                    if (quest.id !== undefined) {
-                      patchSideMutation.mutate(quest.id);
-                      handleCheckboxClick(index);
-                    }
-                  }}
-                  content={quest.content}
-                />
+                  if (quest.id !== undefined) {
+                    const questStatus = sideQuests[index].status || 'ON_PROGRESS';
+                    const newStatus = questStatus === 'COMPLETED' ? 'ON_PROGRESS' : 'COMPLETED';
+                    
+                    patchSideMutation.mutate({ param: quest.id, status: newStatus }, {
+                      onSuccess: () => {
+                        setSideQuests((prev) => {
+                          const newState = [...prev];
+                          newState[index] = {
+                            ...newState[index],
+                            status: newStatus
+                          };
+                      return newState;
+                    });
+                  handleCheckboxClick(index);
+                  }
+                });
+              }
+            }}
+            content={quest.content}
+/>
               ) : null
             )
           ) : (

--- a/client/src/components/SideBox.tsx
+++ b/client/src/components/SideBox.tsx
@@ -20,7 +20,6 @@ const SideBox: React.FC<SideBoxProps> = ({ isAccordion, checked, onClick, conten
 
 const SideBoxStyle = styled.div`
   position: relative;
-  left: 44px;
 
   display: flex;
   align-items: center;

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -14,6 +14,7 @@ import {
   QuestDifficulty,
   QuestHiddenType,
   QuestMode,
+  QuestStatus,
   SideContent,
 } from '@/models/quest.model';
 import { formattedDate } from '@/utils/formatter';
@@ -38,7 +39,6 @@ export const useMainQuest = () => {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const navigate = useNavigate();
-
   const queryClient = useQueryClient();
 
   const {
@@ -95,12 +95,14 @@ export const useMainQuest = () => {
   });
 
   const patchSideMutation = useMutation({
-    mutationFn: modiSideQuest,
-    onSuccess(res) {},
+    mutationFn: ({ param, status }: { param: number; status: QuestStatus }) => modiSideQuest(param, status),
+    onSuccess(res) {
+      
+    },
     onError(err) {
       navigate('/error');
     },
-  });
+});
 
   const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
 

--- a/client/src/hooks/useRank.ts
+++ b/client/src/hooks/useRank.ts
@@ -13,19 +13,22 @@ export const useRank = () => {
     queryFn: () => getRanking(),
   });
 
+  return { rankingData };
+
   // const {
   //   data,
   //   isLoading,
   //   isError,
+  //   fetchNextPage,
+  //   hasNextPage,
   // } = useInfiniteQuery({
   //   queryKey: [...RANK.GET_RANKING],
-  //   queryFn: ({ pageParam = 0 }) => getRanking({ pageParam }),
-  //     getNextPageParam: (result, pages) => { // result 가 결과값, pages 는 이전까지의 결과값들
-  //       if (!result.isLastPage) return result.pageNum;
-  //       return null;
-  //     },
-  //   });
+  //   queryFn: ({ pageParam = 0 }) => getRanking({ pageParam, rankingPerPage: 10 }),
+  //   getNextPageParam: (lastPage) => {
+  //     if (!lastPage.isLastPage) return lastPage.pageNum;
+  //     return null;
+  //   },
   // });
 
-  return { rankingData };
+  // return { rankingData: data, isLoading, isError, fetchNextPage, hasNextPage };
 };

--- a/client/src/pages/CreateMainQuest.tsx
+++ b/client/src/pages/CreateMainQuest.tsx
@@ -52,27 +52,30 @@ const CreateMainQuest = () => {
         <form onSubmit={onSubmit}>
           <QuestInputBox placeholder="퀘스트 제목" {...register('title')} />
           <QuestButtonContainer>
-          <Button
+            <Button
+              type='button'
               className={`easyButton ${isDifficulty === 0 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(0)}
               children={'EASY'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
             <Button
+              type='button'
               className={`normalButton ${isDifficulty === 1 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(1)}
               children={'NORMAL'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
             <Button
+              type='button'
               className={`hardButton ${isDifficulty === 2 ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty(2)}
               children={'HARD'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
           </QuestButtonContainer>
           <div className="plusContainer">
             <h1>퀘스트 추가</h1>

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -69,26 +69,29 @@ const EditMainQuestQuest = () => {
           />
           <QuestButtonContainer>
             <Button
+              type='button'
               className={`easyButton ${isDifficulty === 'EASY' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('EASY')}
               children={'EASY'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
             <Button
+              type='button'
               className={`normalButton ${isDifficulty === 'NORMAL' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('NORMAL')}
               children={'NORMAL'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
             <Button
+              type='button'
               className={`hardButton ${isDifficulty === 'HARD' ? 'isActive' : ''}`}
               onClick={() => setIsDifficulty('HARD')}
               children={'HARD'}
               size={'medium'}
               color={'white'}
-            ></Button>
+            />
           </QuestButtonContainer>
           <div className="plusContainer">
           </div>
@@ -151,6 +154,7 @@ const EditMainQuestQuest = () => {
               color={'black'}
             />
             <Button
+              type='button'
               className="closeButton"
               children={'삭제'}
               size={'medium'}

--- a/client/src/pages/Ranking.tsx
+++ b/client/src/pages/Ranking.tsx
@@ -52,3 +52,38 @@ const RankingStyle = styled.div`
 `;
 
 export default Ranking;
+
+// const RankingCardList = () => {
+//   const { rankingData, fetchNextPage, hasNextPage } = useRank();
+//   const loader = useRef(null);
+
+//   const handleObserver = (entities) => {
+//     const target = entities[0];
+//     if (target.isIntersecting) {
+//       fetchNextPage();
+//     }
+//   };
+
+//   useEffect(() => {
+//     var options = {
+//       root: null,
+//       rootMargin: "20px",
+//       threshold: 1.0
+//     };
+//     const observer = new IntersectionObserver(handleObserver, options);
+//     if (loader.current) {
+//       observer.observe(loader.current)
+//     }
+//   }, []);
+
+//   return (
+//     <>
+//       <RankingCardListStyle>
+//         {rankingData?.pages.flatMap((page, i) => (
+//           page.ranking.map((item) => <RankingCard key={item.id} {...item} />)
+//         ))}
+//         <div ref={loader} />
+//       </RankingCardListStyle>
+//     </>
+//   );
+// };


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- [x] 메인화면에서 사이드박스 status값 변하지않는 버그 수정
- [x] 버튼 클릭시 submit되는 오류 수정
- [ ] 랭킹페이지 무한스크롤 코드 주석처리 

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ 메인화면에서 사이드박스 status값 변하지않는 버그 수정
```tsx
// MainBox.tsx
const [sideQuests, setSideQuests] = useState(content.sideQuests);
  const fraction = `${sideQuests.filter((item) => item.status === 'COMPLETED').length} / ${content.sideQuests.length}`;

<SideBoxContainer>
  {content && content.sideQuests ? (
    content.sideQuests.map((quest, index) =>
      quest.content ? (
        <SideBox
          key={index}
          isAccordion={isAccordion}
          checked={sideQuests[index].status === 'COMPLETED'}
          onClick={() => {
          if (quest.id !== undefined) {
            const questStatus = sideQuests[index].status || 'ON_PROGRESS';
            const newStatus = questStatus === 'COMPLETED' ? 'ON_PROGRESS' : 'COMPLETED';
            
            patchSideMutation.mutate({ param: quest.id, status: newStatus }, {
              onSuccess: () => {
                setSideQuests((prev) => {
                  const newState = [...prev];
                  newState[index] = {
                    ...newState[index],
                    status: newStatus
                  };
              return newState;
            });
          handleCheckboxClick(index);
          }
        });
      }
    }}
    content={quest.content}
    />) : null
    )
  ) : (
    <div>내용이 없습니다.</div>
  )}
</SideBoxContainer>
```
<img width="458" alt="스크린샷 2024-05-21 오후 2 20 38" src="https://github.com/ingame-app/ingame/assets/89385423/1681697f-f7aa-4d37-a6fa-893d74514bb6">
<br><br>
<img width="430" alt="스크린샷 2024-05-21 오후 2 20 43" src="https://github.com/ingame-app/ingame/assets/89385423/a73f0f99-cfd6-4615-8bf2-598ea503b354">

#### 🛠️ 버튼 클릭시 submit되는 오류 수정
#### 버튼 타입을 설정해 주지않아서 생기던 오류 수정
```tsx
// EditMainQuest.tsx, CreateMainQuest.tsx
<QuestButtonContainer>
  <Button
    type='button'
    className={`easyButton ${isDifficulty === 'EASY' ? 'isActive' : ''}`}
    onClick={() => setIsDifficulty('EASY')}
    children={'EASY'}
    size={'medium'}
    color={'white'}
  />
  <Button
    type='button'
    className={`normalButton ${isDifficulty === 'NORMAL' ? 'isActive' : ''}`}
    onClick={() => setIsDifficulty('NORMAL')}
    children={'NORMAL'}
    size={'medium'}
    color={'white'}
  />
  <Button
    type='button'
    className={`hardButton ${isDifficulty === 'HARD' ? 'isActive' : ''}`}
    onClick={() => setIsDifficulty('HARD')}
    children={'HARD'}
    size={'medium'}
    color={'white'}
  />
</QuestButtonContainer>
```

#### 🛠️ 무한스크롤 코드 주석처리
```tsx
// ranking.tsx
// const RankingCardList = () => {
//   const { rankingData, fetchNextPage, hasNextPage } = useRank();
//   const loader = useRef(null);

//   const handleObserver = (entities) => {
//     const target = entities[0];
//     if (target.isIntersecting) {
//       fetchNextPage();
//     }
//   };

//   useEffect(() => {
//     var options = {
//       root: null,
//       rootMargin: "20px",
//       threshold: 1.0
//     };
//     const observer = new IntersectionObserver(handleObserver, options);
//     if (loader.current) {
//       observer.observe(loader.current)
//     }
//   }, []);

//   return (
//     <>
//       <RankingCardListStyle>
//         {rankingData?.pages.flatMap((page, i) => (
//           page.ranking.map((item) => <RankingCard key={item.id} {...item} />)
//         ))}
//         <div ref={loader} />
//       </RankingCardListStyle>
//     </>
//   );
// };
```

### 💡 필요한 후속작업이 있어요.

- [ ] 랭킹페이지 무한 스크롤 구현

### 💡 다음 자료를 참고하면 좋아요.

- [useInfiniteQuery로 무한스크롤 구현하기
](https://velog.io/@hamham/useInfiniteQuery%EB%A1%9C-%EB%AC%B4%ED%95%9C%EC%8A%A4%ED%81%AC%EB%A1%A4-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0#%EC%A0%84%EC%B2%B4-%EC%BD%94%EB%93%9C-1)

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
