### PR TITLE
[BE] 메인 퀘스트 개별 조회 기능 추가

### DIFF
--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -87,8 +87,11 @@ export class QuestsController {
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
   @HttpCode(HttpStatus.OK)
-  async findAll(@CurrentUser() user: AccessTokenPayload) {
-    return await this.questsService.findAll(user.id, Mode.Main);
+  async findAll(@CurrentUser() user: AccessTokenPayload, @Query('date') query: string) {
+    const queryDate = query
+      ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
+      : new Date().toISOString().split('T')[0];
+    return await this.questsService.findAll(user.id, Mode.Main, queryDate);
   }
 
   @UseGuards(AuthGuard)
@@ -169,7 +172,7 @@ export class QuestsController {
   async findAllSub(@CurrentUser() user: AccessTokenPayload, @Query('date') query: string) {
     const queryDate = query
       ? query.replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3')
-      : new Date().toISOString().replace(/(\d{4})(\d{2})(\d{2})/g, '$1-$2-$3');
+      : new Date().toISOString().split('T')[0];
     return await this.questsService.findAll(user.id, Mode.Sub, queryDate);
   }
 

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -82,6 +82,13 @@ export class QuestsController {
   @Get('main')
   @ApiOperation({ summary: '메인 퀘스트 전체 조회' })
   @ApiBearerAuth('accessToken')
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    type: String,
+    description: '조회 일자',
+    example: '20240521',
+  })
   @ApiOkResponse({ type: [CreateQuestDto] })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
@@ -164,6 +171,13 @@ export class QuestsController {
   @Get('sub')
   @ApiOperation({ summary: '서브(일일) 퀘스트 전체 조회' })
   @ApiBearerAuth('accessToken')
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    type: String,
+    description: '조회 일자',
+    example: '20240521',
+  })
   @ApiOkResponse({ type: [SubQuestResponseDto] })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -92,6 +92,20 @@ export class QuestsController {
   }
 
   @UseGuards(AuthGuard)
+  @Get('main/:id')
+  @ApiOperation({ summary: '메인 퀘스트 개별 조회' })
+  @ApiBearerAuth('accessToken')
+  @ApiQuery({ name: 'id', type: Number, description: '퀘스트 ID' })
+  @ApiOkResponse({ type: [CreateQuestDto] })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiNotFoundResponse({ description: 'fail - Quests not found' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  @HttpCode(HttpStatus.OK)
+  async findOne(@CurrentUser() user: AccessTokenPayload, @Param('id') id: string) {
+    return await this.questsService.findOne(user.id, +id);
+  }
+
+  @UseGuards(AuthGuard)
   @Patch('main/:id')
   @ApiOperation({ summary: '메인 퀘스트 개별 수정' })
   @ApiBearerAuth('accessToken')

--- a/server/src/apis/quests/quests.controller.ts
+++ b/server/src/apis/quests/quests.controller.ts
@@ -106,7 +106,7 @@ export class QuestsController {
   @ApiOperation({ summary: '메인 퀘스트 개별 조회' })
   @ApiBearerAuth('accessToken')
   @ApiQuery({ name: 'id', type: Number, description: '퀘스트 ID' })
-  @ApiOkResponse({ type: [CreateQuestDto] })
+  @ApiOkResponse({ type: CreateQuestDto })
   @ApiUnauthorizedResponse({ description: 'Unauthorized' })
   @ApiNotFoundResponse({ description: 'fail - Quests not found' })
   @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -103,6 +103,36 @@ export class QuestsService {
     return quests;
   }
 
+  async findOne(userId: number, questId: number) {
+    const options: FindManyOptions<Quest> = {
+      where: { id: questId, userId: userId, mode: Mode.Main },
+      order: {
+        id: 'DESC',
+      },
+      relations: ['sideQuests'],
+      select: [
+        'id',
+        'title',
+        'difficulty',
+        'mode',
+        'startDate',
+        'endDate',
+        'hidden',
+        'status',
+        'createdAt',
+        'updatedAt',
+      ],
+    };
+
+    const quests = await this.questRepository.find(options);
+
+    if (!quests) {
+      throw new HttpException('fail - Quests not found', HttpStatus.NOT_FOUND);
+    }
+
+    return quests;
+  }
+
   async update(userId: number, questId: number, updateQuestDto: UpdateQuestDto) {
     const currentDate = new Date();
     const queryRunner = this.dataSource.createQueryRunner();

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -129,7 +129,7 @@ export class QuestsService {
       ],
     };
 
-    const quests = await this.questRepository.find(options);
+    const quests = await this.questRepository.findOne(options);
 
     if (!quests) {
       throw new HttpException('fail - Quests not found', HttpStatus.NOT_FOUND);

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -4,7 +4,7 @@ import { UpdateQuestDto } from './dto/update-quest.dto';
 import { UpdateSideQuestDto } from './dto/update-side-quest.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Quest } from './entities/quest.entity';
-import { DataSource, FindManyOptions, Repository } from 'typeorm';
+import { DataSource, FindManyOptions, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
 import { SideQuest } from './entities/side-quest.entity';
 import { Difficulty, Mode, Status } from './enums/quest.enum';
 
@@ -69,7 +69,12 @@ export class QuestsService {
 
   async findAll(userId: number, mode: Mode, queryDate: string) {
     const mainOptions: FindManyOptions<Quest> = {
-      where: { userId: userId, mode: Mode.Main, startDate: queryDate },
+      where: {
+        userId: userId,
+        mode: Mode.Main,
+        startDate: LessThanOrEqual(queryDate),
+        endDate: MoreThanOrEqual(queryDate),
+      },
       order: {
         id: 'DESC',
       },

--- a/server/src/apis/quests/quests.service.ts
+++ b/server/src/apis/quests/quests.service.ts
@@ -67,9 +67,9 @@ export class QuestsService {
     return { message: 'success' };
   }
 
-  async findAll(userId: number, mode: Mode, queryDate?: string) {
+  async findAll(userId: number, mode: Mode, queryDate: string) {
     const mainOptions: FindManyOptions<Quest> = {
-      where: { userId: userId, mode: Mode.Main },
+      where: { userId: userId, mode: Mode.Main, startDate: queryDate },
       order: {
         id: 'DESC',
       },


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- 메인 / 서브 퀘스트 개별 조회 기능 추가
  <br><br>

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

- 퀘스트 API 서비스 객체에 메서드 추가
```ts
/* quests.service.ts */
  async findOne(userId: number, questId: number) {
    const options: FindManyOptions<Quest> = {
      where: { id: questId, userId: userId, mode: Mode.Main },
      order: {
        id: 'DESC',
      },
      relations: ['sideQuests'],
      select: [
        'id',
        'title',
        'difficulty',
        'mode',
        'startDate',
        'endDate',
        'hidden',
        'status',
        'createdAt',
        'updatedAt',
      ],
    };

    const quests = await this.questRepository.findOne(options);

    if (!quests) {
      throw new HttpException('fail - Quests not found', HttpStatus.NOT_FOUND);
    }

    return quests;
  }
```
- 퀘스트 전체 조회 시 date 파라미터 추가로 조회 일자 구간 설정
```ts
/* quests.service.ts */
...
      where: {
        userId: userId,
        mode: Mode.Main,
        startDate: LessThanOrEqual(queryDate),
        endDate: MoreThanOrEqual(queryDate),
      },
...
```
  <br><br>

### 💡 필요한 후속작업이 있어요.

- (없음)
  <br><br>

### 💡 다음 자료를 참고하면 좋아요.

- (없음 -> 팀 노션 페이지 API 명세 참조)
  <br><br>

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [x] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
