### PR TITLE
[FE] 메인퀘스트 날짜대로 표시 기능 추가 및 메인퀘스트 수정페이지 오류해결

### DIFF
--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -14,15 +14,15 @@ export interface ModifyQuestStatusProps {
 }
 
 type CreateQuestData = Omit<Quest, 'id' | 'status' | 'createdAt' | 'updatedAt'>;
-type ModifyQuestData = Omit<Quest, 'mode' | 'status' | 'createdAt' | 'updatedAt'>;
+export type ModifyQuestData = Omit<Quest, 'mode' | 'status' | 'createdAt' | 'updatedAt'>;
 
 export const createMainQuest = async (data: CreateQuestData) => {
   const response = await httpClient.post(API_END_POINT.CREATE_QUEST, { ...data });
   return response.data;
 };
 
-export const modiMainQuest = async (data: ModifyQuestData) => {
-  const response = await httpClient.patch(API_END_POINT.MAIN_QUEST + `/${data.id}`, { ...data });
+export const modiMainQuest = async (id: number, data: ModifyQuestData) => {
+  const response = await httpClient.patch(API_END_POINT.MAIN_QUEST + `/${id}`, { ...data });
   return response.data;
 };
 

--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -31,8 +31,8 @@ export const deleteMainQuest = async (id: number) => {
   return response.data;
 };
 
-export const getMainQuest = async () => {
-  const response = await httpClient.get<Quest[]>(API_END_POINT.MAIN_QUEST);
+export const getMainQuest = async (param: GetSubQuestParam) => {
+  const response = await httpClient.get<Quest[]>(API_END_POINT.MAIN_QUEST, { params: param });
   return response.data;
 };
 

--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -14,7 +14,7 @@ export interface ModifyQuestStatusProps {
 }
 
 type CreateQuestData = Omit<Quest, 'id' | 'status' | 'createdAt' | 'updatedAt'>;
-export type ModifyQuestData = Omit<Quest, 'mode' | 'status' | 'createdAt' | 'updatedAt'>;
+export type ModifyQuestData = Omit<Quest, 'id' | 'mode' | 'status' | 'createdAt' | 'updatedAt'>;
 
 export const createMainQuest = async (data: CreateQuestData) => {
   const response = await httpClient.post(API_END_POINT.CREATE_QUEST, { ...data });

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -10,6 +10,9 @@ import { useNavigate } from 'react-router-dom';
 import { useMainQuest } from '@/hooks/useMainQuest';
 import { formattedDate } from '@/utils/formatter';
 import { useMessage } from '@/hooks/useMessage';
+import { BASE_KEY } from '@/constant/queryKey';
+import { useQuery } from '@tanstack/react-query';
+import { getFindOneMainQuest } from '@/api/quests.api';
 
 interface MainQuest extends Quest {
   sideQuests: SideContent[];
@@ -27,6 +30,15 @@ const MainBox = ({ content }: MainBoxProps) => {
   const [checked, setChecked] = useState(Array(sideQuestList.length).fill(false));
   const [sideQuests, setSideQuests] = useState(content.sideQuests);
   const fraction = `${sideQuests.filter((item) => item.status === 'COMPLETED').length} / ${content.sideQuests.length}`;
+
+  const {
+    data,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: [BASE_KEY.QUEST],
+    queryFn: () => getFindOneMainQuest(content.id),
+  });
 
   const handleChangeStatue = () => {
     if (date === formattedDate(new Date())) {
@@ -60,7 +72,7 @@ const MainBox = ({ content }: MainBoxProps) => {
   const handleNavigate = (event: React.MouseEvent) => {
     event.stopPropagation();
     if (content.status === 'COMPLETED') return;
-    navigate(`/editquest/${content.id}`, { state: { content } });
+    navigate(`/editquest/${content.id}`, { state: { data } });
   };
 
 

--- a/client/src/components/MainBox.tsx
+++ b/client/src/components/MainBox.tsx
@@ -10,9 +10,6 @@ import { useNavigate } from 'react-router-dom';
 import { useMainQuest } from '@/hooks/useMainQuest';
 import { formattedDate } from '@/utils/formatter';
 import { useMessage } from '@/hooks/useMessage';
-// import { getFindOneMainQuest } from '@/api/quests.api';
-// import { BASE_KEY } from '@/constant/queryKey';
-// import { useQuery } from '@tanstack/react-query';
 
 interface MainQuest extends Quest {
   sideQuests: SideContent[];

--- a/client/src/components/WeekCalendar.tsx
+++ b/client/src/components/WeekCalendar.tsx
@@ -6,12 +6,14 @@ import { media } from '@/styles/theme';
 import { QUERYSTRING } from '@/constant/queryString';
 import { useSearchParams } from 'react-router-dom';
 import { formattedDate } from '@/utils/formatter';
+import { useMainQuest } from '@/hooks/useMainQuest';
 
 const Week = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const newSearchParams = new URLSearchParams(searchParams);
 
   const { today, getWeekDates } = useWeek();
+  const { mainQuest, date } = useMainQuest();
 
   const [calendarDay, setCalendarDay] = useState<Date[]>(getWeekDates(today));
   const [now, setNow] = useState<Date>(today);

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -64,7 +64,10 @@ export const useMainQuest = () => {
   });
 
   const EditQuestMutation = useMutation({
-    mutationFn: (variable: ModifyQuestData) => modiMainQuest(variable.id, variable),
+    mutationFn: (variable: Quest) => {
+      const { id, ...rest } = variable;
+      return modiMainQuest(id, rest);
+    },
     onSuccess(res) {
       navigate('/');
     },

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -1,4 +1,5 @@
 import {
+  ModifyQuestData,
   ModifyQuestStatusProps,
   createMainQuest,
   deleteMainQuest,
@@ -63,7 +64,7 @@ export const useMainQuest = () => {
   });
 
   const EditQuestMutation = useMutation({
-    mutationFn: modiMainQuest,
+    mutationFn: (variable: ModifyQuestData) => modiMainQuest(variable.id, variable),
     onSuccess(res) {
       navigate('/');
     },

--- a/client/src/hooks/useMainQuest.ts
+++ b/client/src/hooks/useMainQuest.ts
@@ -41,13 +41,15 @@ export const useMainQuest = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
+  const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
+
   const {
     data: mainQuest,
     isLoading: isMainLoading,
     error,
   } = useQuery({
-    queryKey: [BASE_KEY.QUEST],
-    queryFn: () => getMainQuest(),
+    queryKey: [BASE_KEY.QUEST, date],
+    queryFn: () => getMainQuest({ date }),
   });
 
   const CreateQuestMutation = useMutation({
@@ -103,8 +105,6 @@ export const useMainQuest = () => {
       navigate('/error');
     },
 });
-
-  const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
 
   return {
     mainQuest,

--- a/client/src/hooks/useSubQuest.ts
+++ b/client/src/hooks/useSubQuest.ts
@@ -7,7 +7,7 @@ import {
 } from '@/api/quests.api';
 import { CreateSubQuestProps } from '@/components/modals/CreateSubQuestModal';
 import { SubQuestModifyProps } from '@/components/modals/SubQuestModal';
-import { QUEST } from '@/constant/queryKey';
+import { BASE_KEY, QUEST } from '@/constant/queryKey';
 import { QUERYSTRING } from '@/constant/queryString';
 import { formattedDate } from '@/utils/formatter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -20,7 +20,7 @@ export const useSubQuest = () => {
   const queryClient = useQueryClient();
 
   const { data: subQuestList, isLoading: isSubLoading } = useQuery({
-    queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+    queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
     queryFn: () =>
       getSubQuest({
         date: params.get(QUERYSTRING.DATE) || formattedDate(new Date()),

--- a/client/src/pages/CreateMainQuest.tsx
+++ b/client/src/pages/CreateMainQuest.tsx
@@ -110,7 +110,7 @@ const CreateMainQuest = () => {
             <input
               className="startDate"
               type="date"
-              value={today}
+              value={startDate || today}
               {...register('startDate', {
                 required: true,
                 onChange: (e) => setStartDate(e.target.value),

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -4,46 +4,30 @@ import { CiUnlock } from 'react-icons/ci';
 import Button from '@/components/Button';
 import QuestInputBox from '@/components/QuestInputBox';
 import { media } from '@/styles/theme';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { QuestHiddenType, SideContent } from '@/models/quest.model';
 import CloseButton from '@/components/CloseButton';
 import { useForm } from 'react-hook-form';
 import { EditMainQuestQuestProps, useMainQuest } from '@/hooks/useMainQuest';
 import { useMessage } from '@/hooks/useMessage';
-import { getFindOneMainQuest } from '@/api/quests.api';
-import { useQuery } from '@tanstack/react-query';
-import { BASE_KEY } from '@/constant/queryKey';
 
 const EditMainQuestQuest = () => {
   // MainBox에서 Content 값
   const { state } = useLocation();
-  const {
-    data,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: [BASE_KEY.QUEST],
-    queryFn: () => getFindOneMainQuest(state.content.id),
-  });
+  const data = state.data;
   
-  const [startDate, setStartDate] = useState(data?.startDate);
-  const [endDate, setEndDate] = useState(data?.endDate);
-  const [title, setTitle] = useState(data?.title);
-  const [isDifficulty, setIsDifficulty] = useState(data?.difficulty);
-  const [sideQuests, setSideQuests] = useState(data?.sideQuests);
-  const [isPrivate, setIsPrivate] = useState(data?.hidden === 'TRUE' ? true : false);
+  const [startDate, setStartDate] = useState(data.startDate);
+  const [endDate, setEndDate] = useState(data.endDate);
+  const [title, setTitle] = useState(data.title);
+  const [isDifficulty, setIsDifficulty] = useState(data.difficulty);
+  const [sideQuests, setSideQuests] = useState(data.sideQuests);
+  const [isPrivate, setIsPrivate] = useState(data.hidden === 'TRUE' ? true : false);
   const { EditQuestMutation, DeleteMainQuestsMutation } = useMainQuest();
   const { showConfirm } = useMessage();
   const navigate = useNavigate();
 
   const { register, control, handleSubmit } = useForm<EditMainQuestQuestProps>();
-
-  useEffect(() => {
-    setStartDate(data?.startDate);
-    setEndDate(data?.endDate);
-    setTitle(data?.title);
-  }, [data?.startDate, data?.endDate, data?.title]);
 
   const onSubmit = handleSubmit((data) => {
     const hidden = (isPrivate ? 'TRUE' : 'FALSE') as QuestHiddenType;
@@ -80,7 +64,6 @@ const EditMainQuestQuest = () => {
         </header>
         <form onSubmit={onSubmit}>
           <input type="hidden" value={isDifficulty} {...register('difficulty')} />
-          <input type="hidden" value={data?.id} {...register('id')} />
           <QuestInputBox
             value={title}
             {...register('title')}
@@ -115,8 +98,8 @@ const EditMainQuestQuest = () => {
           <div className="plusContainer">
           </div>
           <InnerQuests>
-            {data?.sideQuests &&
-              data?.sideQuests.map((sideQuest: SideContent, index: number) => (
+            {data.sideQuests &&
+              data.sideQuests.map((sideQuest: SideContent, index: number) => (
                 <SideBoxContainer key={index}>
                   <input
                     className="checkBoxInput"

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -15,14 +15,14 @@ import { useMessage } from '@/hooks/useMessage';
 const EditMainQuestQuest = () => {
   // MainBox에서 Content 값
   const { state } = useLocation();
-  const data = state.data;
+  const content = state.data;
   
-  const [startDate, setStartDate] = useState(data.startDate);
-  const [endDate, setEndDate] = useState(data.endDate);
-  const [title, setTitle] = useState(data.title);
-  const [isDifficulty, setIsDifficulty] = useState(data.difficulty);
-  const [sideQuests, setSideQuests] = useState(data.sideQuests);
-  const [isPrivate, setIsPrivate] = useState(data.hidden === 'TRUE' ? true : false);
+  const [startDate, setStartDate] = useState(content.startDate);
+  const [endDate, setEndDate] = useState(content.endDate);
+  const [title, setTitle] = useState(content.title);
+  const [isDifficulty, setIsDifficulty] = useState(content.difficulty);
+  const [sideQuests, setSideQuests] = useState(content.sideQuests);
+  const [isPrivate, setIsPrivate] = useState(content.hidden === 'TRUE' ? true : false);
   const { EditQuestMutation, DeleteMainQuestsMutation } = useMainQuest();
   const { showConfirm } = useMessage();
   const navigate = useNavigate();
@@ -43,8 +43,8 @@ const EditMainQuestQuest = () => {
   const handleDeleteBtn = () => {
     const message = '정말 삭제하시겠습니까?';
     showConfirm(message, () => {
-      if (data && data.id !== undefined) {
-        DeleteMainQuestsMutation.mutate(data.id);
+      if (content && content.id !== undefined) {
+        DeleteMainQuestsMutation.mutate(content.id);
       }
     });
   };
@@ -65,7 +65,7 @@ const EditMainQuestQuest = () => {
         </header>
         <form onSubmit={onSubmit}>
           <input type="hidden" value={isDifficulty} {...register('difficulty')} />
-          <input type="hidden" value={data.id} {...register('id')} />
+          <input type="hidden" value={content.id} {...register('id')} />
           <QuestInputBox
             value={title}
             {...register('title')}
@@ -100,8 +100,8 @@ const EditMainQuestQuest = () => {
           <div className="plusContainer">
           </div>
           <InnerQuests>
-            {data.sideQuests &&
-              data.sideQuests.map((sideQuest: SideContent, index: number) => (
+            {content.sideQuests &&
+              content.sideQuests.map((sideQuest: SideContent, index: number) => (
                 <SideBoxContainer key={index}>
                   <input
                     className="checkBoxInput"

--- a/client/src/pages/EditMainQuest.tsx
+++ b/client/src/pages/EditMainQuest.tsx
@@ -35,7 +35,8 @@ const EditMainQuestQuest = () => {
       ...sideQuest, 
       status: sideQuest.status
     }));
-    const newData = { ...data, hidden: hidden, sideQuests: updatedSideQuests};
+    const { id, ...rest } = data;
+    const newData = { id, ...rest, hidden: hidden, sideQuests: updatedSideQuests };
     EditQuestMutation.mutate(newData);
   });
 
@@ -64,6 +65,7 @@ const EditMainQuestQuest = () => {
         </header>
         <form onSubmit={onSubmit}>
           <input type="hidden" value={isDifficulty} {...register('difficulty')} />
+          <input type="hidden" value={data.id} {...register('id')} />
           <QuestInputBox
             value={title}
             {...register('title')}

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -10,10 +10,13 @@ import { BiNotepad } from 'react-icons/bi';
 import CreateMainQuestButton from '@/components/CreateMainQuestButton';
 import { useMainQuest } from '@/hooks/useMainQuest';
 import MainBox from '@/components/MainBox';
+import { useLocation } from 'react-router-dom';
 
 const Main = () => {
   const { quest, isSubLoading } = useSubQuest();
-  const { mainQuest, isMainLoading } = useMainQuest();
+  const { mainQuest, isMainLoading, date } = useMainQuest();
+  const location = useLocation();
+  const updatedData = location.state?.updatedData;
 
   return (
     <MainStyle>
@@ -28,7 +31,7 @@ const Main = () => {
         </div>
         <div>
           {mainQuest?.length ? (
-            mainQuest?.map((content) => <MainBox key={content.id} content={content} />)
+            mainQuest?.map((content) => <MainBox key={content.id} content={content} date={date} updatedData={updatedData} />)
           ) : isMainLoading ? (
             <Loading />
           ) : (

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -28,7 +28,7 @@ const Main = () => {
         </div>
         <div>
           {mainQuest?.length ? (
-            mainQuest.map((content) => <MainBox key={content.id} content={content} />)
+            mainQuest?.map((content) => <MainBox key={content.id} content={content} />)
           ) : isMainLoading ? (
             <Loading />
           ) : (


### PR DESCRIPTION
Closes #156, #162 

### 💡 다음 이슈를 해결했어요.
- [x] 메인퀘스트 날짜대로 표시 기능 추가
- [x] 메인퀘스트 수정 시 오류 해결
- [x] 갱신되지 않은 데이터를 받는 오류 해결

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ 메인퀘스트 날짜대로 표시 기능 추가
```ts
// quest.api.ts

export const getMainQuest = async (param: GetSubQuestParam) => {
  const response = await httpClient.get<Quest[]>(API_END_POINT.MAIN_QUEST, { params: param });
```
```ts
// useMainQuest.ts

const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());

  const {
    data: mainQuest,
    isLoading: isMainLoading,
    error,
  } = useQuery({
    queryKey: [BASE_KEY.QUEST, date],
    queryFn: () => getMainQuest({ date }),
  });
```
<img width="428" alt="스크린샷 2024-05-22 오후 3 32 16" src="https://github.com/ingame-app/ingame/assets/89385423/8d5292c3-35d9-4cb0-870d-f1f7329e8f58">
<br><br>
<img width="470" alt="스크린샷 2024-05-22 오후 3 33 38" src="https://github.com/ingame-app/ingame/assets/89385423/b813e1f2-2c7e-49d3-8a94-7d13620c414a">
<br><br>
<img width="467" alt="스크린샷 2024-05-22 오후 3 33 46" src="https://github.com/ingame-app/ingame/assets/89385423/6814e6d2-ea0b-4969-af78-24f067518f62">

#### 🛠️ 메인퀘스트 수정 시 오류 해결
기존에 body에서 id값을 받았으나 url에서 받도록 바꿨습니다. body값에서 받을 시 충돌오류가 생겼습니다.
```ts
// quest.api.ts
export const modiMainQuest = async (id: number, data: ModifyQuestData) => {
  const response = await httpClient.patch(API_END_POINT.MAIN_QUEST + `/${id}`, { ...data });
  return response.data;
};
```

```ts
// useMainQuest.ts
const EditQuestMutation = useMutation({
    mutationFn: (variable: Quest) => {
      const { id, ...rest } = variable;
      return modiMainQuest(id, rest);
    },
    onSuccess(res) {
      navigate('/');
    },
    onError(err) {
      navigate('/error');
    },
  });
```
<br><br>

```tsx
// EditMainQuest.tsx

const onSubmit = handleSubmit((data) => {
    const hidden = (isPrivate ? 'TRUE' : 'FALSE') as QuestHiddenType;
    const updatedSideQuests = (sideQuests || []).map((sideQuest: SideContent) => ({
      ...sideQuest, 
      status: sideQuest.status
    }));
    const { id, ...rest } = data;
    const newData = { id, ...rest, hidden: hidden, sideQuests: updatedSideQuests };
    EditQuestMutation.mutate(newData);
  });
```

#### 🛠️ 갱신되지 않은 데이터를 받는 오류 해결
MainBox.tsx에서 메인퀘스트 개별조회 api로 data를 받고 status값이 바뀔때마다 쿼리 캐시 업데이트로 값을 갱신 시켜줬습니다
```tsx
// MainBox.tsx

const { data, isLoading, error } = useQuery({
  queryKey: [BASE_KEY.QUEST, content.id],
  queryFn: () => getFindOneMainQuest(content.id),
});

 // 쿼리 캐시 업데이트
queryClient.setQueryData([BASE_KEY.QUEST, content.id], (oldData: Quest) => {
  return {
    ...oldData,
    sideQuests: oldData.sideQuests.map((item, i) => 
      i === index ? { ...item, status: newStatus } : item
    )
  };
});
```
#### EditMainQuest에서 navigate에 updatedData값을 넣어서 Main에 전송 후 props값으로 updatedData값이 존재 할 시 기존 데이터를 대신하여 사용해서 문제 해결했습니다
```tsx
// Main.tsx
const Main = () => {
  const { quest, isSubLoading } = useSubQuest();
  const { mainQuest, isMainLoading, date } = useMainQuest();
  const location = useLocation();
  const updatedData = location.state?.updatedData;

  return (
    <MainStyle>
      <Dropdown />
      <WeekCalendar />
      <UserProfile />
      <section className="questSection">
        <div className="questTitle">
          <BiNotepad />
          <h2>Main Quest</h2>
          <CreateMainQuestButton />
        </div>
        <div>
          {mainQuest?.length ? (
            mainQuest?.map((content) => <MainBox key={content.id} content={content} date={date} updatedData={updatedData} />)
          ) : isMainLoading ? (
            <Loading />
          ) : (
            <p>등록된 메인 퀘스트가 없습니다</p>
          )}
        </div>
      </section>
      <section className="questSection">
        <div className="questTitle">
          <BiNotepad />
          <h2>Sub Quest</h2>
          <CreateSubQuestButton />
        </div>
        <div>
          {quest?.length ? (
            quest.map((content) => <SubBox key={content.id} content={content} />)
          ) : isSubLoading ? (
            <Loading />
          ) : (
            <p>등록된 서브 퀘스트가 없습니다</p>
          )}
        </div>
      </section>
    </MainStyle>
  );
};
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
