### PR TITLE
[FE] 서브퀘스트 삭제 추가

### DIFF
--- a/client/src/api/quests.api.ts
+++ b/client/src/api/quests.api.ts
@@ -39,7 +39,7 @@ export const getMainQuest = async () => {
 export const getFindOneMainQuest = async (id: number) => {
   const response = await httpClient.get<Quest>(API_END_POINT.MAIN_QUEST + `/${id}`);
   return response.data;
-}
+};
 
 export const modiSideQuest = async (param: number, status: QuestStatus) => {
   const response = await httpClient.patch(API_END_POINT.SIDE_QUEST + `/${param}`, { status });
@@ -61,6 +61,11 @@ export const modiSubQuest = async (data: SubQuestModifyProps) => {
 
 export const addSubQuest = async (data: CreateSubQuestProps) => {
   const response = await httpClient.post(API_END_POINT.CREATE_QUEST, { ...data });
+  return response.data;
+};
+
+export const delSubQuest = async (id: number) => {
+  const response = await httpClient.delete(API_END_POINT.SUB_QUEST + `/${id}`);
   return response.data;
 };
 

--- a/client/src/components/CloseButton.tsx
+++ b/client/src/components/CloseButton.tsx
@@ -8,7 +8,7 @@ interface CloseButtonProps {
 const CloseButton = ({ onClick }: CloseButtonProps) => {
   return (
     <CloseButtonStyle>
-      <IoIosCloseCircleOutline className="closeIcon" onClick={onClick} />
+      <IoIosCloseCircleOutline color="black" className="closeIcon" onClick={onClick} />
     </CloseButtonStyle>
   );
 };

--- a/client/src/components/modals/SubQuestModal.tsx
+++ b/client/src/components/modals/SubQuestModal.tsx
@@ -28,7 +28,7 @@ const SubQuestModal = ({ onClose, OriginTitle, id, OriginHidden }: SubQuestModal
 
   const { register, handleSubmit, setValue } = useForm<SubQuestModifyProps>();
 
-  const { modifySubQuest } = useSubQuest();
+  const { modifySubQuest, deleteSubQuest } = useSubQuest();
 
   const onSubmit = (data: SubQuestModifyProps) => {
     modifySubQuest(data).then(() => {
@@ -69,7 +69,13 @@ const SubQuestModal = ({ onClose, OriginTitle, id, OriginHidden }: SubQuestModal
         </BoxStyle>
         <ButtonContainerStyle>
           <Button type="submit" size="medium" color="green" children={'수정하기'} />
-          <Button onClick={onClose} size="medium" color="grayNormal" children={'닫기'} />
+          <Button
+            type="button"
+            onClick={() => deleteSubQuest(id)}
+            size="medium"
+            color="grayNormal"
+            children={'삭제하기'}
+          />
         </ButtonContainerStyle>
       </form>
     </SubQuestModalStyle>
@@ -115,6 +121,7 @@ const BoxStyle = styled.div<BoxStyleProps>`
 
     .title {
       font-family: 'Pretendard600';
+      color: ${({ theme }) => theme.color.black};
     }
   }
 

--- a/client/src/hooks/useSubQuest.ts
+++ b/client/src/hooks/useSubQuest.ts
@@ -1,6 +1,7 @@
 import {
   ModifyQuestStatusProps,
   addSubQuest,
+  delSubQuest,
   getSubQuest,
   modiQuestStatus,
   modiSubQuest,
@@ -12,15 +13,18 @@ import { QUERYSTRING } from '@/constant/queryString';
 import { formattedDate } from '@/utils/formatter';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useLocation } from 'react-router-dom';
+import { useMessage } from './useMessage';
 
 export const useSubQuest = () => {
   const location = useLocation();
   const params = new URLSearchParams(location.search);
 
+  const { showConfirm } = useMessage();
+
   const queryClient = useQueryClient();
 
   const { data: subQuestList, isLoading: isSubLoading } = useQuery({
-    queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+    queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
     queryFn: () =>
       getSubQuest({
         date: params.get(QUERYSTRING.DATE) || formattedDate(new Date()),
@@ -35,7 +39,7 @@ export const useSubQuest = () => {
     mutationFn: modiSubQuest,
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
       });
     },
     onError(err) {},
@@ -49,7 +53,7 @@ export const useSubQuest = () => {
     mutationFn: modiQuestStatus,
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
       });
     },
     onError(err) {},
@@ -63,10 +67,25 @@ export const useSubQuest = () => {
     mutationFn: addSubQuest,
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: [...QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
       });
     },
     onError(err) {},
+  });
+
+  const deleteSubQuest = async (id: number) => {
+    showConfirm('서브 퀘스트를 삭제하시겠습니까?', () => {
+      deleteSubQuestMutation.mutate(id);
+    });
+  };
+
+  const deleteSubQuestMutation = useMutation({
+    mutationFn: delSubQuest,
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
+      });
+    },
   });
 
   const date = params.get(QUERYSTRING.DATE) || formattedDate(new Date());
@@ -76,6 +95,7 @@ export const useSubQuest = () => {
     isSubLoading,
     modifySubQuest,
     modifySubQuestStatus,
+    deleteSubQuest,
     date,
     createSubQuest,
   };


### PR DESCRIPTION

<strong>
Closes #158 
</strong>


### 💡 다음 이슈를 해결했어요.
- 서브퀘스트 삭제 기능 추가

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ 서브퀘스트 삭제 API 추가
##### ✔️ quests.api.ts
```ts
...
export const delSubQuest = async (id: number) => {
  const response = await httpClient.delete(API_END_POINT.SUB_QUEST + `/${id}`);
  return response.data;
};

...
```
##### ✔️ useSubQuest.ts 추가
```ts
...

  const deleteSubQuest = async (id: number) => {
    showConfirm('서브 퀘스트를 삭제하시겠습니까?', () => {
      deleteSubQuestMutation.mutate(id);
    });
  };

  const deleteSubQuestMutation = useMutation({
    mutationFn: delSubQuest,
    onSuccess() {
      queryClient.invalidateQueries({
        queryKey: [QUEST.GET_SUBQUEST, params.get(QUERYSTRING.DATE)],
      });
    },
  });

...

```

##### ✔️ 서브퀘스트 모달 수정
버튼에 타입을 명시해줘야 버튼에 달려있는 onClick 이벤트만 이뤄진다.
```tsx
...

 <Button
            type="button"
            onClick={() => deleteSubQuest(id)}
            size="medium"
            color="grayNormal"
            children={'삭제하기'}
          />
...
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
