### PR TITLE
[FE] styles.css를 globalstyles.ts로 합치기

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,7 +21,6 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link rel="stylesheet" href="styles.css" />
     <title>InGame : 퀘스트로 표현하는 당신의 일상</title>
   </head>
   <body>

--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -1,6 +1,0 @@
-body {
-  background-color: #d1eae7;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}

--- a/client/src/styles/globalstyles.ts
+++ b/client/src/styles/globalstyles.ts
@@ -16,6 +16,10 @@ export const GlobalStyle = createGlobalStyle`
 
   body {
     font-family: "Pretendard500";
+    background-color: #d1eae7;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   button,


### PR DESCRIPTION

<strong>
Closes #172 
</strong>

### 💡 다음 이슈를 해결했어요.
index.html에 적용한 전역 스타일을 기존 적영한 globalstyles.ts에 합치기

### 💡 이슈를 처리하면서 추가된 코드가 있어요.
#### 🛠️ styles.css 의 body 값 합치기
```ts
...


  body {
    font-family: "Pretendard500";
    background-color: #d1eae7;
    display: flex;
    justify-content: center;
    align-items: center;
  }

...

```


### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
