### PR TITLE
[BE] 랭킹 조회 기능 수정 완료

### DIFF
--- a/server/src/apis/ranking/dto/user-info-with-rank.dto.ts
+++ b/server/src/apis/ranking/dto/user-info-with-rank.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { UserProfileDto } from 'src/apis/users/dto/user-profile.dto';
+
+export class UserInfoWithRankDto extends PickType(UserProfileDto, [
+  'id',
+  'nickname',
+  'point',
+] as const) {
+  @ApiProperty({
+    example: 1,
+    description: '순위',
+    required: true,
+  })
+  rank: number;
+}

--- a/server/src/apis/ranking/dto/user-ranking.dto.ts
+++ b/server/src/apis/ranking/dto/user-ranking.dto.ts
@@ -1,16 +1,11 @@
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { UserProfileDto } from 'src/apis/users/dto/user-profile.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserInfoWithRankDto } from './user-info-with-rank.dto';
 
-export class UserRankingDto extends PickType(UserProfileDto, [
-  'id',
-  'nickname',
-  'point',
-  'level',
-] as const) {
+export class UserRankingDto extends UserInfoWithRankDto {
   @ApiProperty({
     example: 1,
-    description: '순위',
+    description: '레벨',
     required: true,
   })
-  rank: number;
+  level: number;
 }

--- a/server/src/apis/ranking/ranking.service.ts
+++ b/server/src/apis/ranking/ranking.service.ts
@@ -18,7 +18,6 @@ export class RankingService {
   ): Promise<UserRankingByPageDto> {
     const { page, limit } = paginationRequestDto;
     const [usersInfo, total] = await this.usersService.getUsersWithRankByPage(page, limit);
-    console.log(usersInfo);
 
     const ranking: UserRankingDto[] = usersInfo.map((userInfo) => {
       return this.toRankingResponse(userInfo);

--- a/server/src/apis/ranking/ranking.service.ts
+++ b/server/src/apis/ranking/ranking.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
-import { UserRankingDto } from './dto/user-ranking.dto';
-import { UserInfo } from '../users/entities/user-info.entity';
+import { UserInfoWithRankDto } from './dto/user-info-with-rank.dto';
 import { LevelCalculatorService } from 'src/common/level-calculator/level-calculator.service';
 import { PaginationRequestDto } from './dto/pagination-request.dto';
 import { UserRankingByPageDto } from './dto/user-ranking-by-page.dto';
 import { PaginationResponseDto } from './dto/pagination-response.dto';
+import { UserRankingDto } from './dto/user-ranking.dto';
 
 @Injectable()
 export class RankingService {
@@ -17,23 +17,11 @@ export class RankingService {
     paginationRequestDto: PaginationRequestDto
   ): Promise<UserRankingByPageDto> {
     const { page, limit } = paginationRequestDto;
-    const [users, total] = await this.usersService.getAllUserByPage(page, limit);
-    let currentRank = 1;
-    let lastUserPoint = 0;
-    let countCurrentRank = 0;
+    const [usersInfo, total] = await this.usersService.getUsersWithRankByPage(page, limit);
+    console.log(usersInfo);
 
-    const ranking: UserRankingDto[] = users.map((user) => {
-      if (user.point !== lastUserPoint) {
-        currentRank += countCurrentRank;
-        countCurrentRank = 1;
-      } else {
-        countCurrentRank++;
-      }
-
-      const rankedUser = this.toRankingResponse(user, currentRank);
-
-      lastUserPoint = user.point;
-      return rankedUser;
+    const ranking: UserRankingDto[] = usersInfo.map((userInfo) => {
+      return this.toRankingResponse(userInfo);
     });
 
     const pagination: PaginationResponseDto = {
@@ -49,14 +37,14 @@ export class RankingService {
     return rankingByPage;
   }
 
-  private toRankingResponse(userInfo: UserInfo, rank: number): UserRankingDto {
+  private toRankingResponse(userInfo: UserInfoWithRankDto): UserRankingDto {
     const level = this.levelCalculatorService.findLevel(userInfo.point).level;
 
     return {
-      id: userInfo.userId,
+      id: userInfo.id,
       nickname: userInfo.nickname,
       point: userInfo.point,
-      rank: rank,
+      rank: userInfo.rank,
       level,
     };
   }


### PR DESCRIPTION
<strong>
Closes #
</strong>


### 💡 다음 이슈를 해결했어요.

- 랭킹 조회 시, 페이지네이션 구현 중 다음 페이지로 넘ㅇ어갈 경우 랭킹이 새로 계산되는 문제 해결

### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### rank 함수를 이용해서 랭킹을 데이터베이스에서 계산하기
- 애플리케이션에서 rank를 계산하지 않고 데이터베이스에서 계산하기
- RANK() 함수 이용하기
```ts
// users.service.ts
  async getUsersWithRankByPage(
    page: number,
    limit: number
  ): Promise<[UserInfoWithRankDto[], number]> {
    const offset = (page - 1) * limit;

    const usersInfo: UserInfoWithRankDto[] = await this.userInfoRepository
      .createQueryBuilder('userInfo')
      .select('userInfo.id', 'id')
      .addSelect('userInfo.nickname', 'nickname')
      .addSelect('userInfo.point', 'point')
      .addSelect('RANK() OVER (ORDER BY userInfo.point DESC)', 'rank')
      .orderBy('userInfo.point', 'DESC')
      .limit(limit)
      .offset(offset)
      .getRawMany();

    const total = await this.userInfoRepository.createQueryBuilder('userInfo').getCount();

    return [usersInfo, total];
  }
```

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [x] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
