### PR TITLE
[BE] UserInfo 엔티티 및 커스텀 레포지토리 추가 완료

### DIFF
--- a/server/src/common/dto/ranking/user-info-with-rank.dto.ts
+++ b/server/src/common/dto/ranking/user-info-with-rank.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { UserProfileDto } from 'src/common/dto/user/user-profile.dto';
+import { UserProfileDto } from '../user/user-profile.dto';
 
 export class UserInfoWithRankDto extends PickType(UserProfileDto, [
   'id',

--- a/server/src/core/database/typeorm/generic-typeorm.repository.ts
+++ b/server/src/core/database/typeorm/generic-typeorm.repository.ts
@@ -27,6 +27,6 @@ export abstract class GenericTypeOrmRepository<T extends RootEntity>
   }
 
   protected getRepository(): Repository<T> {
-    return this.transactionManager.getEntityManager().getRepository(this.getTarget());
+    return this.transactionManager.getEntityManager().getRepository(this.getName());
   }
 }

--- a/server/src/entities/user-info/user-info-repository.interface.ts
+++ b/server/src/entities/user-info/user-info-repository.interface.ts
@@ -1,0 +1,10 @@
+import { IGenericRepository } from 'src/core/database/generic/generic.repository';
+import { UserInfo } from './user-info.entity';
+import { UserInfoWithRankDto } from 'src/common/dto/ranking/user-info-with-rank.dto';
+
+export const USER_INFO_REPOSITORY_KEY = 'USER_INFO_REPOSITORY_KEY';
+
+export interface IUserInfoRepository extends IGenericRepository<UserInfo> {
+  getRankings(offset: number, limit: number): Promise<UserInfoWithRankDto[]>;
+  getTotalCount(): Promise<number>;
+}

--- a/server/src/entities/user-info/user-info.entity.ts
+++ b/server/src/entities/user-info/user-info.entity.ts
@@ -1,5 +1,4 @@
 import {
-  BaseEntity,
   Column,
   Entity,
   JoinColumn,
@@ -9,10 +8,11 @@ import {
   Unique,
 } from 'typeorm';
 import { User } from '../user/user.entity';
+import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
 
 @Entity('user_info')
 @Unique(['nickname'])
-export class UserInfo extends BaseEntity {
+export class UserInfo extends BaseTimeEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -31,4 +31,11 @@ export class UserInfo extends BaseEntity {
   @OneToOne(() => User, (user) => user.userInfo, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   user: User;
+
+  static create(userId: number, nickname: string): UserInfo {
+    const userInfo = new UserInfo();
+    userInfo.userId = userId;
+    userInfo.nickname = nickname;
+    return userInfo;
+  }
 }

--- a/server/src/entities/user-info/user-info.module.ts
+++ b/server/src/entities/user-info/user-info.module.ts
@@ -1,0 +1,14 @@
+import { ClassProvider, Module } from '@nestjs/common';
+import { UserInfoRepository } from './user-info.repository';
+import { USER_INFO_REPOSITORY_KEY } from './user-info-repository.interface';
+
+export const userInfoRepository: ClassProvider = {
+  provide: USER_INFO_REPOSITORY_KEY,
+  useClass: UserInfoRepository,
+};
+
+@Module({
+  providers: [userInfoRepository],
+  exports: [userInfoRepository],
+})
+export class UserRepositoryModule {}

--- a/server/src/entities/user-info/user-info.repository.ts
+++ b/server/src/entities/user-info/user-info.repository.ts
@@ -1,0 +1,28 @@
+import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
+import { UserInfo } from './user-info.entity';
+import { IUserInfoRepository } from './user-info-repository.interface';
+import { EntityTarget } from 'typeorm';
+import { UserInfoWithRankDto } from 'src/common/dto/ranking/user-info-with-rank.dto';
+
+export class UserInfoRepository
+  extends GenericTypeOrmRepository<UserInfo>
+  implements IUserInfoRepository
+{
+  getName(): EntityTarget<UserInfo> {
+    return UserInfo.name;
+  }
+  async getRankings(offset: number, limit: number): Promise<UserInfoWithRankDto[]> {
+    return this.getRepository()
+      .createQueryBuilder('userInfo')
+      .select('userInfo.id', 'id')
+      .addSelect('userInfo.nickname', 'nickname')
+      .addSelect('SELECT COUNT(*) + 1 FROM user_info ui WHERE ui.point > userInfo.point', 'rank')
+      .orderBy('userInfo.point', 'DESC')
+      .offset(offset)
+      .limit(limit)
+      .getRawMany();
+  }
+  async getTotalCount(): Promise<number> {
+    return this.getRepository().count();
+  }
+}

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Transactional } from 'src/core/decorators/transactional.decorator';
 import { TransactionManager } from 'src/core/database/typeorm/transaction-manager';
 import { encryptValue } from 'src/common/utils/encrypt-value.util';
-import { UserInfoWithRankDto } from '../../common/dto/ranking/user-info-with-rank.dto';
+import { UserInfoWithRankDto } from 'src/common/dto/ranking/user-info-with-rank.dto';
 
 @Injectable()
 export class UserService {


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

- UserInfo 엔티티에 static create 메서드 추가
- UserInfo 커스텀 레포지토리 생성

### 💡 필요한 후속작업이 있어요.

- ProfilePhoto 엔티티에 static create 메서드 추가
- ProfilePhoto 커스텀 레포지토리 생성

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
