### PR TITLE
[BE] ProfilePhoto 엔티티 수정 및 커스템 레포지토리 추가 완료

### DIFF
--- a/server/src/common/dto/user/profile-photo.dto.ts
+++ b/server/src/common/dto/user/profile-photo.dto.ts
@@ -9,5 +9,5 @@ export class ProfilePhotoDto {
   @IsOptional()
   @IsNotEmpty()
   @IsString()
-  profilePhoto: string;
+  profilePhotoUrl: string;
 }

--- a/server/src/common/dto/user/user-profile.dto.ts
+++ b/server/src/common/dto/user/user-profile.dto.ts
@@ -34,7 +34,7 @@ export class UserProfileDto {
     description: '프로필 사진',
     required: false,
   })
-  profilePhoto: string | null;
+  profilePhotoUrl: string | null;
 
   @ApiProperty({
     example: 0,

--- a/server/src/entities/profile-photo/profile-photo-repository.interface.ts
+++ b/server/src/entities/profile-photo/profile-photo-repository.interface.ts
@@ -1,0 +1,12 @@
+import { IGenericRepository } from 'src/core/database/generic/generic.repository';
+import { ProfilePhoto } from './profile-photo.entity';
+
+export const PROFILE_PHOTO_REPOSITORY_KEY = 'PROFILE_PHOTO_REPOSITORY_KEY';
+
+export interface IProfilePhotoRepository extends IGenericRepository<ProfilePhoto> {
+  findOneByUserId(userId: number): Promise<ProfilePhoto | null>;
+  updateByUserId(
+    profilePhoto: ProfilePhoto,
+    updateData: Partial<ProfilePhoto>
+  ): Promise<ProfilePhoto>;
+}

--- a/server/src/entities/profile-photo/profile-photo-repository.module.ts
+++ b/server/src/entities/profile-photo/profile-photo-repository.module.ts
@@ -1,0 +1,14 @@
+import { ClassProvider, Module } from '@nestjs/common';
+import { PROFILE_PHOTO_REPOSITORY_KEY } from './profile-photo-repository.interface';
+import { ProfilePhotoRepository } from './profile-photo.repository';
+
+export const profilePhotoRepository: ClassProvider = {
+  provide: PROFILE_PHOTO_REPOSITORY_KEY,
+  useClass: ProfilePhotoRepository,
+};
+
+@Module({
+  providers: [profilePhotoRepository],
+  exports: [profilePhotoRepository],
+})
+export class ProfilePhotoRepositoryModule {}

--- a/server/src/entities/profile-photo/profile-photo.entity.ts
+++ b/server/src/entities/profile-photo/profile-photo.entity.ts
@@ -18,9 +18,15 @@ export class ProfilePhoto extends BaseEntity {
   userId: number;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
-  profilePhoto: string;
+  profilePhotoUrl: string;
 
   @OneToOne(() => User, (user) => user.profilePhoto, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'user_id' })
   user: User;
+
+  create(profilePhotoUrl: string): ProfilePhoto {
+    const profilePhoto = new ProfilePhoto();
+    profilePhoto.profilePhotoUrl = profilePhotoUrl;
+    return profilePhoto;
+  }
 }

--- a/server/src/entities/profile-photo/profile-photo.repository.ts
+++ b/server/src/entities/profile-photo/profile-photo.repository.ts
@@ -1,0 +1,24 @@
+import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
+import { ProfilePhoto } from './profile-photo.entity';
+import { IProfilePhotoRepository } from './profile-photo-repository.interface';
+import { EntityTarget } from 'typeorm';
+
+export class ProfilePhotoRepository
+  extends GenericTypeOrmRepository<ProfilePhoto>
+  implements IProfilePhotoRepository
+{
+  getName(): EntityTarget<ProfilePhoto> {
+    return ProfilePhoto.name;
+  }
+
+  async findOneByUserId(userId: number): Promise<ProfilePhoto> {
+    return this.getRepository().findOneBy({ userId });
+  }
+
+  async updateByUserId(
+    profilePhoto: ProfilePhoto,
+    updateData: Partial<ProfilePhoto>
+  ): Promise<ProfilePhoto> {
+    return this.getRepository().merge(profilePhoto, updateData);
+  }
+}

--- a/server/src/entities/user/user.repository.ts
+++ b/server/src/entities/user/user.repository.ts
@@ -8,7 +8,7 @@ export class UserRepository extends GenericTypeOrmRepository<User> implements IU
     return User.name;
   }
 
-  findOneByEmail(email: string): Promise<User> {
+  async findOneByEmail(email: string): Promise<User> {
     return this.getRepository().findOneBy({ email });
   }
 }

--- a/server/src/modules/user/user.service.ts
+++ b/server/src/modules/user/user.service.ts
@@ -140,7 +140,7 @@ export class UserService {
       email: user.email,
       nickname: user.userInfo.nickname,
       intro: user.userInfo.intro ?? null,
-      profilePhoto: user.profilePhoto.profilePhoto ?? null,
+      profilePhotoUrl: user.profilePhoto.profilePhotoUrl ?? null,
       point: user.userInfo.point,
       level,
     };


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.
- ProfilePhoto 엔티티에 static create 메서드 추가
- ProfilePhoto 커스텀 레포지토리 생성
### 💡 필요한 후속작업이 있어요.
- quest와 side quest 엔티티에 static create 메서드 추가
- quest와 side quest 커스텀 레포지토리 생성

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
