### PR TITLE
[BE] 퀘스트 엔티티 수정 및 레포지토리 추가 완료

### DIFF
--- a/server/src/core/database/generic/generic.repository.ts
+++ b/server/src/core/database/generic/generic.repository.ts
@@ -2,6 +2,5 @@ import { RootEntity } from './root.entity';
 
 export interface IGenericRepository<T extends RootEntity> {
   save(t: T | T[]): Promise<T[]>;
-  findById(id: number): Promise<T | null>;
   remove(t: T | T[]): Promise<void>;
 }

--- a/server/src/core/database/typeorm/generic-typeorm.repository.ts
+++ b/server/src/core/database/typeorm/generic-typeorm.repository.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 import { IGenericRepository } from '../generic/generic.repository';
 import { RootEntity } from '../generic/root.entity';
 import { TransactionManager } from 'src/core/database/typeorm/transaction-manager';
-import { EntityTarget, FindOneOptions, Repository } from 'typeorm';
+import { EntityTarget, Repository } from 'typeorm';
 
 export abstract class GenericTypeOrmRepository<T extends RootEntity>
   implements IGenericRepository<T>
@@ -15,11 +15,6 @@ export abstract class GenericTypeOrmRepository<T extends RootEntity>
 
   async save(entity: T | T[]): Promise<T[]> {
     return this.getRepository().save(Array.isArray(entity) ? entity : [entity]);
-  }
-
-  async findById(id: number): Promise<T | null> {
-    const findOption: FindOneOptions = { where: { id } };
-    return this.getRepository().findOne(findOption);
   }
 
   async remove(entity: T | T[]): Promise<void> {

--- a/server/src/entities/quest/quest-repository.interface.ts
+++ b/server/src/entities/quest/quest-repository.interface.ts
@@ -1,0 +1,11 @@
+import { IGenericRepository } from 'src/core/database/generic/generic.repository';
+import { Quest } from './quest.entity';
+
+export const QUEST_REPOSITORY_KEY = 'questRepositoryKey';
+
+export interface IQuestRepository extends IGenericRepository<Quest> {
+  findMainQuestsByUserId(userId: number, date: string): Promise<Quest[]>;
+  findSubQuestsByUserId(userId: number, date: string): Promise<Quest[]>;
+  findMainQuestById(id: number, userId: number): Promise<Quest>;
+  findSubQuestById(id: number, userId: number): Promise<Quest>;
+}

--- a/server/src/entities/quest/quest-repository.module.ts
+++ b/server/src/entities/quest/quest-repository.module.ts
@@ -1,0 +1,14 @@
+import { ClassProvider, Module } from '@nestjs/common';
+import { QUEST_REPOSITORY_KEY } from './quest-repository.interface';
+import { QuestRepository } from './quest.repository';
+
+export const questRepository: ClassProvider = {
+  provide: QUEST_REPOSITORY_KEY,
+  useClass: QuestRepository,
+};
+
+@Module({
+  providers: [questRepository],
+  exports: [questRepository],
+})
+export class QuestRepositoryModule {}

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -6,6 +6,11 @@ import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
 
 @Entity('quest')
 export class Quest extends BaseTimeEntity {
+  constructor(questData: Partial<Quest>) {
+    super();
+    Object.assign(this, questData);
+  }
+
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -40,25 +45,4 @@ export class Quest extends BaseTimeEntity {
 
   @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest)
   sideQuests: SideQuest[];
-
-  static create(
-    userId: number,
-    title: string,
-    difficulty: Difficulty,
-    mode: Mode,
-    hidden: isHidden,
-    startDate: string,
-    endDate: string | null
-  ): Quest {
-    const quest = new Quest();
-    quest.userId = userId;
-    quest.title = title;
-    quest.difficulty = difficulty;
-    quest.mode = mode;
-    quest.hidden = hidden;
-    quest.startDate = startDate;
-    quest.endDate = endDate;
-
-    return quest;
-  }
 }

--- a/server/src/entities/quest/quest.entity.ts
+++ b/server/src/entities/quest/quest.entity.ts
@@ -1,49 +1,64 @@
-import { BaseEntity, Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { User } from '../user/user.entity';
 import { SideQuest } from '../side-quest/side-quest.entity';
 import { Difficulty, isHidden, Mode, Status } from '../../common/types/quest/quest.type';
+import { BaseTimeEntity } from 'src/core/database/typeorm/base-time.entity';
 
 @Entity('quest')
-export class Quest extends BaseEntity {
+export class Quest extends BaseTimeEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column('int', { nullable: false })
+  @Column({ type: 'int', nullable: false })
   userId: number;
 
   @Column({ type: 'varchar', length: 50, nullable: false })
   title: string;
 
-  @Column({ type: 'enum', name: 'difficulty', enum: Difficulty })
-  difficulty!: Difficulty;
+  @Column({ type: 'enum', enum: Difficulty, nullable: false })
+  difficulty: Difficulty;
 
-  @Column({ type: 'enum', name: 'mode', enum: Mode })
-  mode!: Mode;
+  @Column({ type: 'enum', enum: Mode, nullable: false })
+  mode: Mode;
 
-  @Column('date', { nullable: false })
+  @Column({ type: 'enum', enum: isHidden, nullable: false })
+  hidden: isHidden;
+
+  @Column({ type: 'enum', enum: Status, default: Status.onProgress, nullable: false })
+  status: Status;
+
+  @Column({ type: 'varchar', nullable: false })
   startDate: string;
 
-  @Column('date', { nullable: true })
-  endDate: string;
-
-  @Column({ type: 'enum', name: 'hidden', enum: isHidden })
-  hidden!: isHidden;
-
-  @Column({ type: 'enum', name: 'status', enum: Status, default: Status.onProgress })
-  status!: Status;
-
-  @Column('timestamp', { nullable: false, default: () => 'CURRENT_TIMESTAMP' })
-  createdAt: Date;
-
-  @Column('timestamp', { nullable: false, default: () => 'CURRENT_TIMESTAMP' })
-  updatedAt: Date;
+  @Column({ type: 'varchar', nullable: true })
+  endDate: string | null;
 
   @ManyToOne(() => User, (user) => user.quests, {
     onDelete: 'CASCADE',
-    onUpdate: 'CASCADE',
   })
   user: User;
 
   @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest)
   sideQuests: SideQuest[];
+
+  static create(
+    userId: number,
+    title: string,
+    difficulty: Difficulty,
+    mode: Mode,
+    hidden: isHidden,
+    startDate: string,
+    endDate: string | null
+  ): Quest {
+    const quest = new Quest();
+    quest.userId = userId;
+    quest.title = title;
+    quest.difficulty = difficulty;
+    quest.mode = mode;
+    quest.hidden = hidden;
+    quest.startDate = startDate;
+    quest.endDate = endDate;
+
+    return quest;
+  }
 }

--- a/server/src/entities/quest/quest.repository.ts
+++ b/server/src/entities/quest/quest.repository.ts
@@ -1,0 +1,58 @@
+import { GenericTypeOrmRepository } from 'src/core/database/typeorm/generic-typeorm.repository';
+import { Quest } from './quest.entity';
+import { IQuestRepository } from './quest-repository.interface';
+import { EntityTarget, SelectQueryBuilder } from 'typeorm';
+import { Mode } from 'src/common/types/quest/quest.type';
+
+export class QuestRepository extends GenericTypeOrmRepository<Quest> implements IQuestRepository {
+  getName(): EntityTarget<Quest> {
+    return Quest.name;
+  }
+
+  async findMainQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
+    return this.baseSelectQueryBuilder(userId, Mode.Main)
+      .leftJoinAndSelect('quest.sideQuests', 'sideQuest')
+      .andWhere('quest.startDate <= :dateString', { dateString })
+      .andWhere('quest.endDate >= :dateString', { dateString })
+      .orderBy('quest.id', 'DESC')
+      .getMany();
+  }
+
+  async findSubQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
+    return this.baseSelectQueryBuilder(userId, Mode.Sub)
+      .andWhere('quest.startDate = :dateString', { dateString })
+      .orderBy('quest.id', 'DESC')
+      .getMany();
+  }
+
+  async findMainQuestById(id: number, userId: number): Promise<Quest> {
+    return this.baseSelectQueryBuilder(userId, Mode.Main).andWhere('qeust.id=:id', { id }).getOne();
+  }
+
+  async findSubQuestById(id: number, userId: number): Promise<Quest> {
+    return this.baseSelectQueryBuilder(userId, Mode.Sub).andWhere('qeust.id=:id', { id }).getOne();
+  }
+
+  private baseSelectQueryBuilder(userId: number, mode: Mode): SelectQueryBuilder<Quest> {
+    return this.getRepository()
+      .createQueryBuilder('quest')
+      .select(this.getSelectFields(mode))
+      .where('quest.userId = :userId', { userId })
+      .andWhere('quest.mode= :mode', { mode });
+  }
+
+  private getSelectFields(mode: Mode): string[] {
+    const commonFields = [
+      'quest.id',
+      'quest.title',
+      'quest.hidden',
+      'quest.status',
+      'quest.createdAt',
+      'quest.updatedAt',
+    ];
+
+    return mode === Mode.Main
+      ? [...commonFields, 'quest.difficulty', 'quest.startDate', 'quest.endDate']
+      : commonFields;
+  }
+}


### PR DESCRIPTION
### 💡 다음 이슈를 해결했어요.

#### 퀘스트 인스턴스 생성
- 기존에는 create라는 정적 메서드를 이용하여 퀘스트를 생성
- update하기 위해서도 퀘스트 인스턴스를 생성하여야하는데, create와 update 모두 존재한다면, 코드가 너무 복잡해짐
- 또한, 필요한 인자인지 검증하는 과정을 DTO에서 담당하기 때문에, 굳이 엔티티에도 검증할 필요가 없다고 생각
- 따라서, 인자에 대한 유효성 검증은 DTO에게 맡기고 생성자를 이용해 퀘스트 인스턴스 생성
#### 퀘스트 레포지토리 생성
- 쿼리문이 복잡하기 때문에, QueryBuilder를 이용하기로 결정
- interface를 이용해서 QuestRepository에 대한 설계도를 만들고, QuestRepository 구현체 생성
### 💡 이슈를 처리하면서 추가된 코드가 있어요.

#### 퀘스트 엔티티
```ts
@Entity('quest')
export class Quest extends BaseTimeEntity {
  constructor(questData: Partial<Quest>) {
    super();
    Object.assign(this, questData);
  }

  @PrimaryGeneratedColumn()
  id: number;

  @Column({ type: 'int', nullable: false })
  userId: number;

  @Column({ type: 'varchar', length: 50, nullable: false })
  title: string;

  @Column({ type: 'enum', enum: Difficulty, nullable: false })
  difficulty: Difficulty;

  @Column({ type: 'enum', enum: Mode, nullable: false })
  mode: Mode;

  @Column({ type: 'enum', enum: isHidden, nullable: false })
  hidden: isHidden;

  @Column({ type: 'enum', enum: Status, default: Status.onProgress, nullable: false })
  status: Status;

  @Column({ type: 'varchar', nullable: false })
  startDate: string;

  @Column({ type: 'varchar', nullable: true })
  endDate: string | null;

  @ManyToOne(() => User, (user) => user.quests, {
    onDelete: 'CASCADE',
  })
  user: User;

  @OneToMany(() => SideQuest, (sideQuest) => sideQuest.quest)
  sideQuests: SideQuest[];
}
```
#### 퀘스트 레포지토리
```ts
// quest-repository.interface.ts
export interface IQuestRepository extends IGenericRepository<Quest> {
  findMainQuestsByUserId(userId: number, date: string): Promise<Quest[]>;
  findSubQuestsByUserId(userId: number, date: string): Promise<Quest[]>;
  findMainQuestById(id: number, userId: number): Promise<Quest>;
  findSubQuestById(id: number, userId: number): Promise<Quest>;
}

// quest.repository.ts
export class QuestRepository extends GenericTypeOrmRepository<Quest> implements IQuestRepository {
  getName(): EntityTarget<Quest> {
    return Quest.name;
  }

  async findMainQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
    return this.baseSelectQueryBuilder(userId, Mode.Main)
      .leftJoinAndSelect('quest.sideQuests', 'sideQuest')
      .andWhere('quest.startDate <= :dateString', { dateString })
      .andWhere('quest.endDate >= :dateString', { dateString })
      .orderBy('quest.id', 'DESC')
      .getMany();
  }

  async findSubQuestsByUserId(userId: number, dateString: string): Promise<Quest[]> {
    return this.baseSelectQueryBuilder(userId, Mode.Sub)
      .andWhere('quest.startDate = :dateString', { dateString })
      .orderBy('quest.id', 'DESC')
      .getMany();
  }

  async findMainQuestById(id: number, userId: number): Promise<Quest> {
    return this.baseSelectQueryBuilder(userId, Mode.Main).andWhere('qeust.id=:id', { id }).getOne();
  }

  async findSubQuestById(id: number, userId: number): Promise<Quest> {
    return this.baseSelectQueryBuilder(userId, Mode.Sub).andWhere('qeust.id=:id', { id }).getOne();
  }

  private baseSelectQueryBuilder(userId: number, mode: Mode): SelectQueryBuilder<Quest> {
    return this.getRepository()
      .createQueryBuilder('quest')
      .select(this.getSelectFields(mode))
      .where('quest.userId = :userId', { userId })
      .andWhere('quest.mode= :mode', { mode });
  }

  private getSelectFields(mode: Mode): string[] {
    const commonFields = [
      'quest.id',
      'quest.title',
      'quest.hidden',
      'quest.status',
      'quest.createdAt',
      'quest.updatedAt',
    ];

    return mode === Mode.Main
      ? [...commonFields, 'quest.difficulty', 'quest.startDate', 'quest.endDate']
      : commonFields;
  }
}

```

### 💡 필요한 후속작업이 있어요.

- 사이드 퀘스트 엔티티 수정 및 레포지토리 추가

### ✅ 셀프 체크리스트

- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다. (master/main이 아닙니다.)
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
- [ ] 변경 후 코드는 컴파일러/브라우저 warning/error 가 발생시키지 않습니다.
- [ ] 변경 후 코드는 기존의 테스트를 통과합니다.
- [ ] 테스트 추가가 필요한지 검토해보았고, 필요한 경우 테스트를 추가했습니다.
- [ ] docs 수정이 필요한지 검토해보았고, 필요한 경우 docs를 수정했습니다.
